### PR TITLE
Avoid asserting bf:part for language entities, use rdf:value indirection instead

### DIFF
--- a/test/ConvSpec-010-048.xspec
+++ b/test/ConvSpec-010-048.xspec
@@ -172,7 +172,7 @@
 
   <x:scenario label="041 - LANGUAGE CODE">
     <x:context href="data/ConvSpec-010-048/marc.xml"/>
-    <x:expect label="041 create language properties of the Work" test="//bf:Work/bf:language[1]/bf:Language/@rdf:about = 'http://id.loc.gov/vocabulary/languages/eng'"/>
+    <x:expect label="041 create language properties of the Work" test="//bf:Work/bf:language[1]/bf:Language/rdf:value/@rdf:resource = 'http://id.loc.gov/vocabulary/languages/eng'"/>
     <x:expect label="ind1 creates a note property of the Work" test="//bf:Work/bf:note[1]/bf:Note/rdfs:label = 'Includes translation'"/>
     <x:expect label="ind2 determines the source property of the Language" test="//bf:Work/bf:language[4]/bf:Language/bf:source/bf:Source/@rdf:about = 'http://id.loc.gov/vocabulary/iso639-1'"/>
     <x:expect label="subfields other than $a create a part property of the Language" test="//bf:Work/bf:language[2]/bf:Language/bf:part = 'original'"/>

--- a/xsl/ConvSpec-010-048.xsl
+++ b/xsl/ConvSpec-010-048.xsl
@@ -534,10 +534,12 @@
         <xsl:when test="$serialization = 'rdfxml'">
           <bf:language>
             <bf:Language>
-              <xsl:attribute name="rdf:about"><xsl:value-of select="concat($languages,substring($pLang,$pStart,3))"/></xsl:attribute>
               <xsl:if test="$pPart != ''">
                 <bf:part><xsl:value-of select="$pPart"/></bf:part>
               </xsl:if>
+              <rdf:value>
+                <xsl:attribute name="rdf:resource"><xsl:value-of select="concat($languages,substring($pLang,$pStart,3))"/></xsl:attribute>
+              </rdf:value>
               <bf:source>
                 <bf:Source>
                   <xsl:attribute name="rdf:about">http://id.loc.gov/vocabulary/languages</xsl:attribute>


### PR DESCRIPTION
This is a proposed fix for issue #7.

The problem is that the current code asserts `bf:part` properties (such as "original" or "summary") on language entities such as `<http://id.loc.gov/vocabulary/languages/eng>` directly, i.e. triples like this:

```
<http://id.loc.gov/vocabulary/languages/eng> bf:part "original" .
```

This causes problems especially when converting multiple records with different language information.

The proposed fix implemented in this PR is to use a blank node as the `bf:language` value, and add an `rdf:value` property that references the LC language URI. So for e.g. a record that represents a translation from English (`041 $h eng)`, we get these RDF triples:

```
ex:work
  bf:language [
    a bf:Language ;
    bf:part "original" ;
    rdf:value <http://id.loc.gov/vocabulary/languages/eng>
  ] .
```

The PR changes both the XSL implementing the conversion and the XSpec test, making sure that the test passes.

There are other MARC fields (e.g. `008`) that also get converted to `bf:language` properties with `bf:Language` values that get LC-assigned URIs, but AFAICT no record-specific extra information like `bf:part` is asserted for those URIs, so there is no analoguous problem and I decided not to touch their conversions.