### PR TITLE
Provide ant build.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /upstream/
 /saxon/
 /xspec/
+/build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/upstream/
+/saxon/
+/xspec/

--- a/build.properties
+++ b/build.properties
@@ -5,13 +5,14 @@ saxon.version = 9.7.0-15
 saxon.file = Saxon-HE-${saxon.version}.jar
 saxon.url = http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${saxon.version}/${saxon.file}
 saxon.dir = ${basedir}/saxon
+saxon.jar = ${basedir}/saxon/${saxon.file}
 
 # Not using this yet, probably should
 saxon.sum = cfc93468c9d6980fa3947acbf932279d
 
-xspec.version = 0.1
+xspec.version = 0.5.0
 xspec.file = xspec-v${xspec.version}.zip
-xspec.url = https://github.com/expath/xspec/archive/${xspec.file}
+xspec.url = https://github.com/xspec/xspec/archive/v${xspec.version}.zip
 xspec.dir = ${basedir}/xspec
 
 build.version = 0.1

--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,18 @@
+
+upstream.dir = ${basedir}/upstream
+
+saxon.version = 9.7.0-15
+saxon.file = Saxon-HE-${saxon.version}.jar
+saxon.url = http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${saxon.version}/${saxon.file}
+saxon.dir = ${basedir}/saxon
+
+# Not using this yet, probably should
+saxon.sum = cfc93468c9d6980fa3947acbf932279d
+
+xspec.version = 0.1
+xspec.file = xspec-v${xspec.version}.zip
+xspec.url = https://github.com/expath/xspec/archive/${xspec.file}
+xspec.dir = ${basedir}/xspec
+
+build.version = 0.1
+build.dir = build

--- a/build.properties
+++ b/build.properties
@@ -15,5 +15,8 @@ xspec.file = xspec-v${xspec.version}.zip
 xspec.url = https://github.com/xspec/xspec/archive/v${xspec.version}.zip
 xspec.project.dir = ${basedir}/xspec
 
-build.dir = build
 build.version = 0.1
+
+build.dir = build
+dist.dir = ${build.dir}/dist
+dist.file = marc2bibframe2-${build.version}.zip

--- a/build.properties
+++ b/build.properties
@@ -13,7 +13,7 @@ saxon.sum = cfc93468c9d6980fa3947acbf932279d
 xspec.version = 0.5.0
 xspec.file = xspec-v${xspec.version}.zip
 xspec.url = https://github.com/xspec/xspec/archive/v${xspec.version}.zip
-xspec.dir = ${basedir}/xspec
+xspec.project.dir = ${basedir}/xspec
 
-build.version = 0.1
 build.dir = build
+build.version = 0.1

--- a/build.xml
+++ b/build.xml
@@ -66,8 +66,18 @@
   <target name="build"
           depends="test"
           description="--> Package Bibframe xsl and metaproxy configuration into a ZIP" >
-    <mkdir dir="${build.dir}"/>
-    <zip basedir="${basedir}/xsl" destfile="${build.dir}/marc2bibframe2-${build.version}.zip"/>
+    <mkdir dir="${build.dir}/marc2bibframe2"/>
+    <copy todir="${build.dir}/marc2bibframe2">
+      <fileset dir="${basedir}">
+        <include name="xsl/**"/>
+        <include name="metaproxy/**"/>
+      </fileset>
+    </copy>
+    <zip destfile="${build.dir}/marc2bibframe2-${build.version}.zip">
+      <fileset dir="${build.dir}">
+        <include name="marc2bibframe2/**"/>
+      </fileset>
+    </zip>
   </target>
 
   <target name="clean"

--- a/build.xml
+++ b/build.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project name="marc2bibframe">
+<project name="marc2bibframe" default="help">
 
   <property file="${user.home}/.marc2bibframe" />
   <property file="build.properties" />
 
   <!-- Once xspec is downloaded and installed, we expect to use it -->
-  <import file="${xspec.dir}/build.xml" optional="true" />
+  <import file="${xspec.project.dir}/build.xml" optional="true" />
+
+  <!-- need foreach to avoid listing xspec files
+    <taskdef resource="net/sf/antcontrib/antcontrib.properties"/>
+   -->
 
   <target name="download-saxon">
     <mkdir dir="${upstream.dir}" />
@@ -23,8 +27,8 @@
   </target>
 
   <target name="install-xspec">
-    <mkdir dir="${xspec.dir}"/>
-    <unzip src="${upstream.dir}/${xspec.file}" dest="${xspec.dir}">
+    <mkdir dir="${xspec.project.dir}"/>
+    <unzip src="${upstream.dir}/${xspec.file}" dest="${xspec.project.dir}">
       <cutdirsmapper dirs="1"/>
     </unzip>
   </target>
@@ -36,7 +40,26 @@
 
   <target name="test"
           description="--> Run xspec tests using Saxon" >
+
+    <!-- Could use ant-contrib to make this easier -->
     <xspec xspec.xml="test/ConvSpec-001-007.xspec" />
+    <xspec xspec.xml="test/ConvSpec-006,008.xspec" />
+    <xspec xspec.xml="test/ConvSpec-010-048.xspec" />
+    <xspec xspec.xml="test/ConvSpec-050-088.xspec" />
+    <xspec xspec.xml="test/ConvSpec-1XX,6XX,7XX,8XX-names.xspec" />
+    <xspec xspec.xml="test/ConvSpec-200-247not240-Titles.xspec" />
+    <xspec xspec.xml="test/ConvSpec-240andX30-UnifTitle.xspec" />
+    <xspec xspec.xml="test/ConvSpec-250-270.xspec" />
+    <xspec xspec.xml="test/ConvSpec-3XX.xspec" />
+    <xspec xspec.xml="test/ConvSpec-490-510-530to535-Links.xspec" />
+    <xspec xspec.xml="test/ConvSpec-5XX.xspec" />
+    <xspec xspec.xml="test/ConvSpec-648-662.xspec" />
+    <xspec xspec.xml="test/ConvSpec-720+740to755.xspec" />
+    <xspec xspec.xml="test/ConvSpec-760-788-Links.xspec" />
+    <xspec xspec.xml="test/ConvSpec-841-887.xspec" />
+    <xspec xspec.xml="test/ConvSpec-880.xspec" />
+    <xspec xspec.xml="test/ConvSpec-LDR.xspec" />
+    <xspec xspec.xml="test/marc2bibframe2.xspec" />
   </target>
 
 
@@ -49,7 +72,13 @@
 
   <target name="clean"
           description="--> Remove artifacts of the earlier build" >
+
+    <!-- This is where the build goes -->
     <delete dir="${build.dir}" />
+
+    <!-- This is where xspec outputs go -->
+    <delete dir="${basedir}/test/xspec" />
+
   </target>
 
   <target name="purge"
@@ -60,6 +89,13 @@
     <delete dir="${xspec.dir}" />
 
     <!-- Go find .vagrant and remove those directories as well? -->
+  </target>
+
+  <target name="help">
+    <echo message="Run first" />
+    <echo message="     ant setup" />
+    <echo message="Run next" />
+    <echo message="     ant build" />
   </target>
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="marc2bibframe">
+
+  <property file="${user.home}/.marc2bibframe" />
+  <property file="build.properties" />
+
+  <target name="download-saxon">
+    <mkdir dir="${upstream.dir}" />
+    <get src="${saxon.url}" dest="${upstream.dir}/${saxon.file}"/>
+  </target>
+
+  <target name="install-saxon">
+    <mkdir dir="${saxon.dir}" />
+    <copy file="${upstream.dir}/${saxon.file}" todir="${saxon.dir}"  overwrite="true" />
+  </target>
+
+  <target name="download-xspec">
+    <mkdir dir="${upstream.dir}" />
+    <get src="${xspec.url}" dest="${upstream.dir}/${xspec.file}"/>
+  </target>
+
+  <target name="install-xspec">
+    <mkdir dir="${xspec.dir}"/>
+    <unzip src="${upstream.dir}/${xspec.file}" dest="${xspec.dir}">
+      <cutdirsmapper dirs="1"/>
+    </unzip>
+  </target>
+
+  <target name="setup"
+          depends="download-saxon, install-saxon, download-xspec, install-xspec"
+          description="--> Download and install testing tools" />
+
+
+  <target name="test"
+          description="--> Run xspec tests using Saxon" >
+  </target>
+
+
+  <target name="build"
+          depends="test"
+          description="--> Package Bibframe xsl and metaproxy configuration into a ZIP" >
+    <mkdir dir="${build.dir}"/>
+    <zip basedir="${basedir}/xsl" destfile="${build.dir}/marc2bibframe2-${build.version}.zip"/>
+  </target>
+
+  <target name="clean"
+          description="--> Remove artifacts of the earlier build" >
+    <delete dir="${build.dir}" />
+  </target>
+
+  <target name="purge"
+          depends="clean"
+          description="--> Removes everything including downloads" >
+    <delete dir="${upstream.dir}" />
+    <delete dir="${saxon.dir}" />
+    <delete dir="${xspec.dir}" />
+
+    <!-- Go find .vagrant and remove those directories as well? -->
+  </target>
+
+</project>

--- a/build.xml
+++ b/build.xml
@@ -37,11 +37,9 @@
           depends="download-saxon, install-saxon, download-xspec, install-xspec"
           description="--> Download and install testing tools" />
 
-
   <target name="test"
-          description="--> Run xspec tests using Saxon" >
+          description="--> Run xspec tests using Saxon">
 
-    <!-- Could use ant-contrib to make this easier -->
     <xspec xspec.xml="test/ConvSpec-001-007.xspec" />
     <xspec xspec.xml="test/ConvSpec-006,008.xspec" />
     <xspec xspec.xml="test/ConvSpec-010-048.xspec" />
@@ -62,9 +60,7 @@
     <xspec xspec.xml="test/marc2bibframe2.xspec" />
   </target>
 
-
-  <target name="build"
-          depends="test"
+  <target name="package"
           description="--> Package Bibframe xsl and metaproxy configuration into a ZIP" >
     <mkdir dir="${build.dir}/marc2bibframe2"/>
     <copy todir="${build.dir}/marc2bibframe2">
@@ -73,12 +69,19 @@
         <include name="metaproxy/**"/>
       </fileset>
     </copy>
-    <zip destfile="${build.dir}/marc2bibframe2-${build.version}.zip">
+    <mkdir dir="${dist.dir}"/>
+    <zip destfile="${dist.dir}/${dist.file}">
       <fileset dir="${build.dir}">
         <include name="marc2bibframe2/**"/>
       </fileset>
     </zip>
+    <checksum file="${dist.dir}/${dist.file}" algorithm="md5" fileext=".md5" format="MD5SUM"/>
+    <checksum file="${dist.dir}/${dist.file}" algorithm="sha-1" fileext=".sha1" format="MD5SUM"/>
   </target>
+
+  <target name="build"
+          depends="test, package"
+          description="--> Run tests and package xsl and metaproxy configuration" />
 
   <target name="clean"
           description="--> Remove artifacts of the earlier build" >

--- a/build.xml
+++ b/build.xml
@@ -4,6 +4,9 @@
   <property file="${user.home}/.marc2bibframe" />
   <property file="build.properties" />
 
+  <!-- Once xspec is downloaded and installed, we expect to use it -->
+  <import file="${xspec.dir}/build.xml" optional="true" />
+
   <target name="download-saxon">
     <mkdir dir="${upstream.dir}" />
     <get src="${saxon.url}" dest="${upstream.dir}/${saxon.file}"/>
@@ -33,6 +36,7 @@
 
   <target name="test"
           description="--> Run xspec tests using Saxon" >
+    <xspec xspec.xml="test/ConvSpec-001-007.xspec" />
   </target>
 
 


### PR DESCRIPTION
This pull request contains an ant `build.xml` file that supports a number of targets.   The expected use of this is to run the following to download xspec 0.5.0 from github and saxon and set them up:

```
ant setup
```

Then, run the following to run the xspec tests and zip up the XSL files for marc2bibframe2

```
ant build
```

The version to release can be changed on the command-line as follows:

```
ant build -Dbuild.version=0.2.0
```

This depends only on ant itself - no ivy or ant contrib needed.
