### PR TITLE
Fix 038 conversion to creata bflc:MetadataLicensor object

### DIFF
--- a/test/ConvSpec-010-048.xspec
+++ b/test/ConvSpec-010-048.xspec
@@ -158,7 +158,7 @@
 
   <x:scenario label="038 - RECORD CONTENT LICENSOR">
     <x:context href="data/ConvSpec-010-048/marc.xml"/>
-    <x:expect label="038 creates a bflc:metadataLicensor property of the Work AdminMetadata" test="//bf:Work/bf:adminMetadata/bf:AdminMetadata/bflc:metadataLicensor/rdfs:label = 'Uk'"/>
+    <x:expect label="038 creates a bflc:metadataLicensor property of the Work AdminMetadata" test="//bf:Work/bf:adminMetadata/bf:AdminMetadata/bflc:metadataLicensor/bflc:MetadataLicensor/rdfs:label = 'Uk'"/>
   </x:scenario>
 
   <x:scenario label="040 - CATALOGING SOURCE">

--- a/test/ConvSpec-250-270.xspec
+++ b/test/ConvSpec-250-270.xspec
@@ -81,7 +81,7 @@
 
   <x:scenario label="263 - PROJECTED PUBLICATION DATE">
     <x:context href="data/ConvSpec-250-270/marc.xml"/>
-    <x:expect label="$a creates a bflc:projectedPubDate property of the Instance" test="//bf:Instance[1]/bflc:projectedPubDate = '1999-XX'"/>
+    <x:expect label="$a creates a bflc:projectedProvisionDate property of the Instance" test="//bf:Instance[1]/bflc:projectedProvisionDate = '1999-XX'"/>
   </x:scenario>
 
   <x:scenario label="264 - PRODUCTION, PUBLICATION, DISTRIBUTION, MANUFACTURE, AND COPYRIGHT NOTICE">

--- a/xsl/ConvSpec-010-048.xsl
+++ b/xsl/ConvSpec-010-048.xsl
@@ -189,7 +189,9 @@
       <xsl:when test="$serialization = 'rdfxml'">
         <xsl:for-each select="marc:subfield[@code='a']">
           <bflc:metadataLicensor>
-            <rdfs:label><xsl:value-of select="."/></rdfs:label>
+            <bflc:MetadataLicensor>
+              <rdfs:label><xsl:value-of select="."/></rdfs:label>
+            </bflc:MetadataLicensor>
           </bflc:metadataLicensor>
         </xsl:for-each>
       </xsl:when>

--- a/xsl/ConvSpec-250-270.xsl
+++ b/xsl/ConvSpec-250-270.xsl
@@ -549,10 +549,10 @@
     <xsl:choose>
       <xsl:when test="$serialization = 'rdfxml'">
         <xsl:if test="$vDate != ''">
-          <bflc:projectedPubDate>
+          <bflc:projectedProvisionDate>
             <xsl:attribute name="rdf:datatype"><xsl:value-of select="concat($edtf,'edtf')"/></xsl:attribute>
             <xsl:value-of select="$vDate"/>
-          </bflc:projectedPubDate>
+          </bflc:projectedProvisionDate>
         </xsl:if>
       </xsl:when>
     </xsl:choose>


### PR DESCRIPTION
Fixes an error in 038 conversion where a bflc:MetadataLicensor object missing between the bf:metadataLicensor and rdfs:label properties. 