### PR TITLE
Correct conversion of hierarchical geographic tags (662, 752)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 --- 1.1.1-SNAPSHOT
 
+Fix conversion of hierarchical geographic tags (662, 752) (fixes lcnetdev/marc2bibframe2#30)
 Update conversion of name fields $e to create bflc:relatorMatchKey property (fixes ntra00/marc2bibframe2#12)
 Fix 340 $i conversion to create SystemRequirement object (fixes ntra00/marc2bibframe2#19)
 Fix 340 $i and 538 conversions to assign correct property and class (systemRequirement/SystemRequirement) (fixes lcnetdev/marc2bibframe2#22)

--- a/test/ConvSpec-648-662.xspec
+++ b/test/ConvSpec-648-662.xspec
@@ -63,6 +63,7 @@
     <x:expect label="...with rdf:type of madsrdf:HierarchicalGeographic" test="//bf:Work[1]/bf:subject[6]/bf:Place/rdf:type/@rdf:resource = 'http://www.loc.gov/mads/rdf/v1#HierarchicalGeographic'"/>
     <x:expect label="$abcdfgh creates an rdfs:label property of the Topic" test="//bf:Work[1]/bf:subject[6]/bf:Place/rdfs:label = 'Japan--Hokkaido--Asahi-dake.'"/>
     <x:expect label="...and become components in the madsrdf:componentList of the Topic" test="//bf:Work[1]/bf:subject[6]/bf:Place/madsrdf:componentList/*[3]/rdfs:label = 'Asahi-dake'"/>
+    <x:expect label="...with the appropriate madsrdf Class" test="//bf:Work[1]/bf:subject[6]/bf:Place/madsrdf:componentList/madsrdf:County/rdfs:label = 'Hokkaido'"/>
   </x:scenario>
   
 </x:description>

--- a/test/ConvSpec-720+740to755.xspec
+++ b/test/ConvSpec-720+740to755.xspec
@@ -24,9 +24,10 @@
 
   <x:scenario label="752 - ADDED ENTRY--HIERARCHICAL PLACE NAME">
     <x:context href="data/ConvSpec-720+740to755/marc.xml"/>
-    <x:expect label="752 creates a place/Place property of the Work" test="//bf:Work[1]/bf:place[1]/bf:Place/rdfs:label = 'England--London'"/>
-    <x:expect label="...with a madsrdf:HierarchicalGeopgraphic Class" test="//bf:Work[1]/bf:place[1]/bf:Place/rdf:type/@rdf:resource = 'http://www.loc.gov/mads/rdf/v1#HierarchicalGeographic'"/>
-    <x:expect label="$abcdfgh become part of the madsrdf:componentList of the Place" test="//bf:Work[1]/bf:place[1]/bf:Place/madsrdf:componentList/*[2]/rdfs:label = 'London'"/>
+    <x:expect label="752 creates a place/Place property of the Work" test="//bf:Work[1]/bf:place[1]/bf:Place/rdfs:label = 'England--Greater London--London'"/>
+    <x:expect label="...with a madsrdf:HierarchicalGeographic Class" test="//bf:Work[1]/bf:place[1]/bf:Place/rdf:type/@rdf:resource = 'http://www.loc.gov/mads/rdf/v1#HierarchicalGeographic'"/>
+    <x:expect label="$abcdfgh become part of the madsrdf:componentList of the Place" test="//bf:Work[1]/bf:place[1]/bf:Place/madsrdf:componentList/*[3]/rdfs:label = 'London'"/>
+    <x:expect label="...with the appropriate madsrdf Class" test="//bf:Work[1]/bf:place[1]/bf:Place/madsrdf:componentList/madsrdf:County/rdfs:label = 'Greater London'"/>
   </x:scenario>
   
   <x:scenario label="753 - SYSTEM DETAILS ACCESS TO COMPUTER FILES">

--- a/test/data/ConvSpec-720+740to755/marc.xml
+++ b/test/data/ConvSpec-720+740to755/marc.xml
@@ -13,6 +13,7 @@
     </datafield>
     <datafield tag="752" ind1=" " ind2=" ">
       <subfield code="a">England</subfield>
+      <subfield code="c">Greater London</subfield>
       <subfield code="d">London</subfield>
       <subfield code="e">publication place.</subfield>
       <subfield code="4">pup</subfield>

--- a/xsl/ConvSpec-648-662.xsl
+++ b/xsl/ConvSpec-648-662.xsl
@@ -412,8 +412,8 @@
                 <xsl:variable name="vResource">
                   <xsl:choose>
                     <xsl:when test="@code='a'">madsrdf:Country</xsl:when>
-                    <xsl:when test="@code='b'">madsrdf:County</xsl:when>
-                    <xsl:when test="@code='c'">madsrdf:State</xsl:when>
+                    <xsl:when test="@code='b'">madsrdf:State</xsl:when>
+                    <xsl:when test="@code='c'">madsrdf:County</xsl:when>
                     <xsl:when test="@code='d'">madsrdf:City</xsl:when>
                     <xsl:when test="@code='f'">madsrdf:CitySection</xsl:when>
                     <xsl:when test="@code='g'">madsrdf:Region</xsl:when>

--- a/xsl/ConvSpec-720+740to755.xsl
+++ b/xsl/ConvSpec-720+740to755.xsl
@@ -59,8 +59,8 @@
                 <xsl:variable name="vResource">
                   <xsl:choose>
                     <xsl:when test="@code='a'">madsrdf:Country</xsl:when>
-                    <xsl:when test="@code='b'">madsrdf:County</xsl:when>
-                    <xsl:when test="@code='c'">madsrdf:State</xsl:when>
+                    <xsl:when test="@code='b'">madsrdf:State</xsl:when>
+                    <xsl:when test="@code='c'">madsrdf:County</xsl:when>
                     <xsl:when test="@code='d'">madsrdf:City</xsl:when>
                     <xsl:when test="@code='f'">madsrdf:CitySection</xsl:when>
                     <xsl:when test="@code='g'">madsrdf:Region</xsl:when>


### PR DESCRIPTION
$b should create a madsrdf:State object, and $c should create madsrdf:County (they were reversed). Fixes lcnetdev/marc2bibframe2#30