### PR TITLE
Fix isMemberOfMADSScheme typo (lower case 'o')

### DIFF
--- a/test/ConvSpec-1XX,6XX,7XX,8XX-names.xspec
+++ b/test/ConvSpec-1XX,6XX,7XX,8XX-names.xspec
@@ -22,7 +22,7 @@
     <x:expect label="...with rdfs:label composed according to Name processing rules" test="//bf:Work[1]/bf:subject[1]/bf:Agent/rdfs:label = 'Nixon, Richard M. (Richard Milhouse), 1913-'"/>
     <x:expect label="...it also has a Class from MADSRDF" test="//bf:Work[1]/bf:subject[1]/bf:Agent/rdf:type[2]/@rdf:resource = 'http://www.loc.gov/mads/rdf/v1#ComplexSubject'"/>
     <x:expect label="...and a madsrdf:authoritativeLabel property" test="//bf:Work[1]/bf:subject[1]/bf:Agent/madsrdf:authoritativeLabel = 'Nixon, Richard M. (Richard Milhouse), 1913---Psychology.'"/>
-    <x:expect label="...and a madsrdf:isMemberofMADSScheme property" test="//bf:Work[1]/bf:subject[1]/bf:Agent/madsrdf:isMemberofMADSScheme/@rdf:resource = 'http://id.loc.gov/authorities/subjects'"/>
+    <x:expect label="...and a madsrdf:isMemberOfMADSScheme property" test="//bf:Work[1]/bf:subject[1]/bf:Agent/madsrdf:isMemberOfMADSScheme/@rdf:resource = 'http://id.loc.gov/authorities/subjects'"/>
     <x:expect label="...ind2 creates a source property of the Agent" test="//bf:Work[1]/bf:subject[1]/bf:Agent/bf:source/bf:Source/bf:code = 'lcsh'"/>
     <x:expect label="600,610,611 with $t creates a subject/Work property of the Work" test="count(//bf:Work[1]/bf:subject/bf:Work) = 1"/>
     <x:expect label="...with contribution from Name portion of field" test="//bf:Work[1]/bf:subject[2]/bf:Work/bf:contribution/bf:Contribution/bf:agent/bf:Agent/rdfs:label = 'Bellamy, Edward, 1850-1898.'"/>

--- a/test/marc2bibframe2.xspec
+++ b/test/marc2bibframe2.xspec
@@ -310,7 +310,7 @@
                 <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
                 <rdfs:label>Jazz--1951-1960.</rdfs:label>
                 <madsrdf:authoritativeLabel>Jazz--1951-1960.</madsrdf:authoritativeLabel>
-                <madsrdf:isMemberofMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+                <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
                 <madsrdf:componentList rdf:parseType="Collection">
                   <madsrdf:Topic>
                     <madsrdf:authoritativeLabel>Jazz</madsrdf:authoritativeLabel>
@@ -331,7 +331,7 @@
                 <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Topic"/>
                 <rdfs:label>Piano with jazz ensemble.</rdfs:label>
                 <madsrdf:authoritativeLabel>Piano with jazz ensemble.</madsrdf:authoritativeLabel>
-                <madsrdf:isMemberofMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+                <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
                 <bf:source>
                   <bf:Source>
                     <bf:code>lcsh</bf:code>
@@ -604,7 +604,7 @@
                 <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
                 <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName"/>
                 <madsrdf:authoritativeLabel>White House (Washington, D.C.)</madsrdf:authoritativeLabel>
-                <madsrdf:isMemberofMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+                <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
                 <bf:source>
                   <bf:Source>
                     <bf:code>lcsh</bf:code>
@@ -620,7 +620,7 @@
                 <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Jurisdiction"/>
                 <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName"/>
                 <madsrdf:authoritativeLabel>United States. Executive Office of the President.</madsrdf:authoritativeLabel>
-                <madsrdf:isMemberofMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+                <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
                 <bf:source>
                   <bf:Source>
                     <bf:code>lcsh</bf:code>
@@ -636,7 +636,7 @@
                 <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Jurisdiction"/>
                 <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName"/>
                 <madsrdf:authoritativeLabel>United States. Office of the Vice President.</madsrdf:authoritativeLabel>
-                <madsrdf:isMemberofMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+                <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
                 <bf:source>
                   <bf:Source>
                     <bf:code>lcsh</bf:code>
@@ -652,7 +652,7 @@
                 <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Jurisdiction"/>
                 <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName"/>
                 <madsrdf:authoritativeLabel>United States. Office of the First Lady.</madsrdf:authoritativeLabel>
-                <madsrdf:isMemberofMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+                <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
                 <bf:source>
                   <bf:Source>
                     <bf:code>lcsh</bf:code>

--- a/xsl/ConvSpec-1XX,6XX,7XX,8XX-names.xsl
+++ b/xsl/ConvSpec-1XX,6XX,7XX,8XX-names.xsl
@@ -130,9 +130,9 @@
                   <xsl:value-of select="$vMADSLabel"/>
                 </madsrdf:authoritativeLabel>
                 <xsl:for-each select="$subjectThesaurus/subjectThesaurus/subject[@ind2=current()/@ind2]/madsscheme">
-                  <madsrdf:isMemberofMADSScheme>
+                  <madsrdf:isMemberOfMADSScheme>
                     <xsl:attribute name="rdf:resource"><xsl:value-of select="."/></xsl:attribute>
-                  </madsrdf:isMemberofMADSScheme>
+                  </madsrdf:isMemberOfMADSScheme>
                 </xsl:for-each>                  
                 <xsl:if test="$vSource != ''">
                   <xsl:copy-of select="$vSource"/>
@@ -752,9 +752,9 @@
                 </madsrdf:authoritativeLabel>
               </xsl:if>
               <xsl:for-each select="$subjectThesaurus/subjectThesaurus/subject[@ind2=current()/@ind2]/madsscheme">
-                <madsrdf:isMemberofMADSScheme>
+                <madsrdf:isMemberOfMADSScheme>
                   <xsl:attribute name="rdf:resource"><xsl:value-of select="."/></xsl:attribute>
-                </madsrdf:isMemberofMADSScheme>
+                </madsrdf:isMemberOfMADSScheme>
               </xsl:for-each>
             </xsl:if>
             <xsl:if test="$pSource != ''">

--- a/xsl/ConvSpec-240andX30-UnifTitle.xsl
+++ b/xsl/ConvSpec-240andX30-UnifTitle.xsl
@@ -117,9 +117,9 @@
             </rdf:type>
             <madsrdf:authoritativeLabel><xsl:value-of select="$vMADSLabel"/></madsrdf:authoritativeLabel>
             <xsl:for-each select="$subjectThesaurus/subjectThesaurus/subject[@ind2=current()/@ind2]/madsscheme">
-              <madsrdf:isMemberofMADSScheme>
+              <madsrdf:isMemberOfMADSScheme>
                 <xsl:attribute name="rdf:resource"><xsl:value-of select="."/></xsl:attribute>
-              </madsrdf:isMemberofMADSScheme>
+              </madsrdf:isMemberOfMADSScheme>
             </xsl:for-each>                  
             <xsl:if test="$vSource != ''">
               <xsl:copy-of select="$vSource"/>

--- a/xsl/ConvSpec-648-662.xsl
+++ b/xsl/ConvSpec-648-662.xsl
@@ -132,9 +132,9 @@
               <xsl:value-of select="$vLabel"/>
             </madsrdf:authoritativeLabel>
             <xsl:for-each select="$subjectThesaurus/subjectThesaurus/subject[@ind2=current()/@ind2]/madsscheme">
-              <madsrdf:isMemberofMADSScheme>
+              <madsrdf:isMemberOfMADSScheme>
                 <xsl:attribute name="rdf:resource"><xsl:value-of select="."/></xsl:attribute>
-              </madsrdf:isMemberofMADSScheme>
+              </madsrdf:isMemberOfMADSScheme>
             </xsl:for-each>
             <!-- build the ComplexSubject -->
             <xsl:if test="$vMADSClass='ComplexSubject'">


### PR DESCRIPTION
Per Adrian Pohl's message to the BIBFRAME mailing list on 2019-01-31,
the XSLT is incorrectly generating the isMemberOfMADSScheme property with a
lowercase 'o'.

Signed-off-by: Dan Scott <dscott@laurentian.ca>