### PR TITLE
Trim ISBD from Work, Instance, and bf:title rdfs:label values

### DIFF
--- a/test/ConvSpec-200-247not240-Titles.xspec
+++ b/test/ConvSpec-200-247not240-Titles.xspec
@@ -111,13 +111,13 @@
   <x:scenario label="245 - TITLE STATEMENT">
     <x:scenario label="@ind2">
       <x:context href="data/ConvSpec-200-247not240-Titles/marc245.xml"/>
-      <x:expect label="should create the appropriate titleSortKey" test="//bf:Instance[1]/bf:title/bf:Title/bflc:titleSortKey = 'Bureau La Oficina = Das Büro.'"/>
+      <x:expect label="should create the appropriate titleSortKey" test="//bf:Instance[1]/bf:title/bf:Title/bflc:titleSortKey = 'Bureau La Oficina = Das Büro'"/>
     </x:scenario>
     <x:scenario label="rdfs:label">
       <x:context href="data/ConvSpec-200-247not240-Titles/marc245.xml"/>
-      <x:expect label="$abfgknps in record order" test="//bf:Instance[2]/bf:title/bf:Title/rdfs:label = 'Annual report of the Minister of Supply and Service Canada under the Corporations and Labour Unions Returns Act. Part II, Labour unions = Rapport annuel du ministre des Approvisionnements et services Canada présenté sous l''empire et des syndicates ouvriers. Partie II, Syndicats ouvriers.'"/>
-      <x:expect label="rdfs:label for Work" test="//bf:Work[2]/rdfs:label = 'Annual report of the Minister of Supply and Service Canada under the Corporations and Labour Unions Returns Act. Part II, Labour unions = Rapport annuel du ministre des Approvisionnements et services Canada présenté sous l''empire et des syndicates ouvriers. Partie II, Syndicats ouvriers.'"/>
-      <x:expect label="rdfs:label for Instance" test="//bf:Instance[2]/rdfs:label = 'Annual report of the Minister of Supply and Service Canada under the Corporations and Labour Unions Returns Act. Part II, Labour unions = Rapport annuel du ministre des Approvisionnements et services Canada présenté sous l''empire et des syndicates ouvriers. Partie II, Syndicats ouvriers.'"/>
+      <x:expect label="$abfgknps in record order" test="//bf:Instance[2]/bf:title/bf:Title/rdfs:label = 'Annual report of the Minister of Supply and Service Canada under the Corporations and Labour Unions Returns Act. Part II, Labour unions = Rapport annuel du ministre des Approvisionnements et services Canada présenté sous l''empire et des syndicates ouvriers. Partie II, Syndicats ouvriers'"/>
+      <x:expect label="rdfs:label for Work" test="//bf:Work[2]/rdfs:label = 'Annual report of the Minister of Supply and Service Canada under the Corporations and Labour Unions Returns Act. Part II, Labour unions = Rapport annuel du ministre des Approvisionnements et services Canada présenté sous l''empire et des syndicates ouvriers. Partie II, Syndicats ouvriers'"/>
+      <x:expect label="rdfs:label for Instance" test="//bf:Instance[2]/rdfs:label = 'Annual report of the Minister of Supply and Service Canada under the Corporations and Labour Unions Returns Act. Part II, Labour unions = Rapport annuel du ministre des Approvisionnements et services Canada présenté sous l''empire et des syndicates ouvriers. Partie II, Syndicats ouvriers'"/>
     </x:scenario>
     <x:scenario label="$a">
       <x:context href="data/ConvSpec-200-247not240-Titles/marc245.xml"/>

--- a/test/ConvSpec-490-510-530to535-Links.xspec
+++ b/test/ConvSpec-490-510-530to535-Links.xspec
@@ -25,7 +25,7 @@
     <x:expect label="530 creates a hasInstance/Instance property of the Work" test="count(//bf:Work[1]/bf:hasInstance/bf:Instance) = 3"/>
     <x:expect label="...with a URI" test="//bf:Work[1]/bf:hasInstance[1]/bf:Instance/@rdf:about = 'http://example.org/1#Instance530-4'"/>
     <x:expect label="...and an instanceOf property" test="//bf:Work[1]/bf:hasInstance[1]/bf:Instance/bf:instanceOf/@rdf:resource = 'http://example.org/1#Work'"/>
-    <x:expect label="...and a title property" test="//bf:Work[1]/bf:hasInstance[1]/bf:Instance/bf:title/bf:Title/rdfs:label = 'Ole Lukøie /'"/>
+    <x:expect label="...and a title property" test="//bf:Work[1]/bf:hasInstance[1]/bf:Instance/bf:title/bf:Title/rdfs:label = 'Ole Lukøie'"/>
     <x:expect label="530 creates a otherPhysicalFormat property of the Instance" test="//bf:Instance[1]/bf:otherPhysicalFormat/@rdf:resource = 'http://example.org/1#Instance530-4'"/>
     <x:expect label="...and an otherPhysicalFormat property of the hasInstance/Instance" test="//bf:Work[1]/bf:hasInstance[1]/bf:Instance/bf:otherPhysicalFormat/@rdf:resource = 'http://example.org/1#Instance'"/>
     <x:expect label="$a creates a note property of the hasInstance/Instance" test="//bf:Work[1]/bf:hasInstance[1]/bf:Instance/bf:note[1]/bf:Note/rdfs:label = 'Available in microfilm'"/>
@@ -41,7 +41,7 @@
     <x:expect label="533 creates a hasInstance/Instance property of the Work" test="count(//bf:Work[1]/bf:hasInstance/bf:Instance) = 3"/>
     <x:expect label="...with a URI" test="//bf:Work[1]/bf:hasInstance[2]/bf:Instance/@rdf:about = 'http://example.org/1#Instance533-5'"/>
     <x:expect label="...and an instanceOf property" test="//bf:Work[1]/bf:hasInstance[2]/bf:Instance/bf:instanceOf/@rdf:resource = 'http://example.org/1#Work'"/>
-    <x:expect label="...and a title property" test="//bf:Work[1]/bf:hasInstance[2]/bf:Instance/bf:title/bf:Title/rdfs:label = 'Ole Lukøie /'"/>
+    <x:expect label="...and a title property" test="//bf:Work[1]/bf:hasInstance[2]/bf:Instance/bf:title/bf:Title/rdfs:label = 'Ole Lukøie'"/>
     <x:expect label="533 creates a hasReproduction property of the Instance" test="//bf:Instance[1]/bf:hasReproduction/@rdf:resource = 'http://example.org/1#Instance533-5'"/>
     <x:expect label="...and an reproductionOf property of the hasInstance/Instance" test="//bf:Work[1]/bf:hasInstance[2]/bf:Instance/bf:reproductionOf/@rdf:resource = 'http://example.org/1#Instance'"/>
     <x:expect label="$a creates a carrier property of the hasInstance/Instance" test="//bf:Work[1]/bf:hasInstance[2]/bf:Instance/bf:carrier/bf:Carrier/rdfs:label = 'Microfilm'"/>

--- a/test/ConvSpec-880.xspec
+++ b/test/ConvSpec-880.xspec
@@ -24,7 +24,7 @@
     <x:expect label="$6 222-xx should make a KeyTitle" test="//bf:Instance[1]/bf:title[2]/bf:Title/rdf:type[2]/@rdf:resource = 'http://id.loc.gov/ontologies/bibframe/KeyTitle'"/>
     <x:expect label="$6 242-xx should make a VariantTitle with varientType 'translated'" test="//bf:Instance[1]/bf:title[3]/bf:Title/bf:variantType = 'translated'"/>
     <x:expect label="$6 243-xx should make a CollectiveTitle" test="//bf:Work[1]/bf:title[2]/bf:Title/rdf:type[2]/@rdf:resource = 'http://id.loc.gov/ontologies/bibframe/CollectiveTitle'"/>
-    <x:expect label="$6 245-xx should make a Title" test="//bf:Instance[1]/bf:title[4]/bf:Title/rdfs:label = '東海道五十三次絵卷.'"/>
+    <x:expect label="$6 245-xx should make a Title" test="//bf:Instance[1]/bf:title[4]/bf:Title/rdfs:label = '東海道五十三次絵卷'"/>
     <x:expect label="$6 246-xx should make a VariantTitle" test="//bf:Instance[1]/bf:title[5]/bf:Title/rdf:type[1]/@rdf:resource = 'http://id.loc.gov/ontologies/bibframe/VariantTitle'"/>
     <x:expect label="$6 247-xx should make a VariantTitle with varientType 'former'" test="//bf:Instance[1]/bf:title[6]/bf:Title/bf:variantType = 'former'"/>
     <x:expect label="$6 250 creates an editionStatement property of the Instance" test="//bf:Instance[1]/bf:editionStatement = 'Третий проект / под редакцией Пола Уотсона'"/>

--- a/test/marc2bibframe2.xspec
+++ b/test/marc2bibframe2.xspec
@@ -117,11 +117,11 @@
                 </bf:role>
               </bf:Contribution>
             </bf:contribution>
-            <rdfs:label>Ole Lukøie /</rdfs:label>
+            <rdfs:label>Ole Lukøie</rdfs:label>
             <bf:title>
               <bf:Title>
-                <rdfs:label>Ole Lukøie /</rdfs:label>
-                <bflc:titleSortKey>Ole Lukøie /</bflc:titleSortKey>
+                <rdfs:label>Ole Lukøie</rdfs:label>
+                <bflc:titleSortKey>Ole Lukøie</bflc:titleSortKey>
                 <bf:mainTitle>Ole Lukøie</bf:mainTitle>
               </bf:Title>
             </bf:title>
@@ -173,11 +173,11 @@
                 <rdf:value>8759517352</rdf:value>
               </bf:Isbn>
             </bf:identifiedBy>
-            <rdfs:label>Ole Lukøie /</rdfs:label>
+            <rdfs:label>Ole Lukøie</rdfs:label>
             <bf:title>
               <bf:Title>
-                <rdfs:label>Ole Lukøie /</rdfs:label>
-                <bflc:titleSortKey>Ole Lukøie /</bflc:titleSortKey>
+                <rdfs:label>Ole Lukøie</rdfs:label>
+                <bflc:titleSortKey>Ole Lukøie</bflc:titleSortKey>
                 <bf:mainTitle>Ole Lukøie</bf:mainTitle>
               </bf:Title>
             </bf:title>

--- a/xsl/ConvSpec-200-247not240-Titles.xsl
+++ b/xsl/ConvSpec-200-247not240-Titles.xsl
@@ -396,7 +396,11 @@
             <xsl:if test="$vXmlLang != ''">
               <xsl:attribute name="xml:lang"><xsl:value-of select="$vXmlLang"/></xsl:attribute>
             </xsl:if>
-            <xsl:value-of select="normalize-space($label)"/>
+            <xsl:call-template name="chopPunctuation">
+              <xsl:with-param name="chopString">
+                <xsl:value-of select="normalize-space($label)"/>
+              </xsl:with-param>
+            </xsl:call-template>
           </rdfs:label>
         </xsl:if>
         <bf:title>
@@ -485,7 +489,11 @@
             <xsl:if test="$vXmlLang != ''">
               <xsl:attribute name="xml:lang"><xsl:value-of select="$vXmlLang"/></xsl:attribute>
             </xsl:if>
-            <xsl:value-of select="normalize-space($label)"/>
+            <xsl:call-template name="chopPunctuation">
+              <xsl:with-param name="chopString">
+                <xsl:value-of select="normalize-space($label)"/>
+              </xsl:with-param>
+            </xsl:call-template>
           </rdfs:label>
         </xsl:if>
         <bf:title>
@@ -543,9 +551,19 @@
               <xsl:if test="$vXmlLang != ''">
                 <xsl:attribute name="xml:lang"><xsl:value-of select="$vXmlLang"/></xsl:attribute>
               </xsl:if>
-              <xsl:value-of select="substring($label,1,string-length($label)-1)"/>
+              <xsl:call-template name="chopPunctuation">
+                <xsl:with-param name="chopString">
+                  <xsl:value-of select="substring($label,1,string-length($label)-1)"/>
+                </xsl:with-param>
+              </xsl:call-template>
             </rdfs:label>
-            <bflc:titleSortKey><xsl:value-of select="substring($label,@ind2+1,(string-length($label)-@ind2)-1)"/></bflc:titleSortKey>
+            <bflc:titleSortKey>
+              <xsl:call-template name="chopPunctuation">
+                <xsl:with-param name="chopString">
+                  <xsl:value-of select="substring($label,@ind2+1,(string-length($label)-@ind2)-1)"/>
+                </xsl:with-param>
+              </xsl:call-template>
+            </bflc:titleSortKey>
           </xsl:if>
           <xsl:for-each select="marc:subfield[@code='a']">
             <bf:mainTitle>


### PR DESCRIPTION
Rather than maintaining ISBD punctuation in the rdfs:label values at the level
of Work, Instance, and bf:title entities, trim the ISBD to match bf:mainTitle.

Closes #104

Signed-off-by: Dan Scott <dscott@laurentian.ca>