### PR TITLE
Update 042 conversion.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 --- 1.5.0-SNAPSHOT
 
+Generate correct property for MARC 042 conversion (https://github.com/lcnetdev/marc2bibframe2/issues/116)
 Remove extra xsl:message logging (https://github.com/lcnetdev/marc2bibframe2/issues/113)
 
 --- 1.4.0 2019/02/15

--- a/test/ConvSpec-010-048.xspec
+++ b/test/ConvSpec-010-048.xspec
@@ -194,6 +194,7 @@
     <x:context href="data/ConvSpec-010-048/marc.xml"/>
     <x:expect label="042 create descriptionAuthentication properties of the Work AdminMetadata" test="//bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:descriptionAuthentication[2]/bf:DescriptionAuthentication/@rdf:about = 'http://id.loc.gov/vocabulary/marcauthen/nsdp'"/>
     <x:expect label="...URI-encoded, if necessary" test="//bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:descriptionAuthentication[3]/bf:DescriptionAuthentication/@rdf:about = 'http://id.loc.gov/vocabulary/marcauthen/pcc%20record'"/>
+    <x:expect label="...with a bf:code property" test="//bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:descriptionAuthentication[2]/bf:DescriptionAuthentication/bf:code='nsdp'"/>
   </x:scenario>
   
   <x:scenario label="043 - GEOGRAPHIC AREA CODE">

--- a/test/marc2bibframe2.xspec
+++ b/test/marc2bibframe2.xspec
@@ -546,7 +546,7 @@
                 </bf:descriptionModifier>
                 <bf:descriptionAuthentication>
                   <bf:DescriptionAuthentication rdf:about="http://id.loc.gov/vocabulary/marcauthen/lccopycat">
-                    <rdfs:label>lccopycat</rdfs:label>
+                    <bf:code>lccopycat</bf:code>
                   </bf:DescriptionAuthentication>
                 </bf:descriptionAuthentication>
               </bf:AdminMetadata>

--- a/xsl/ConvSpec-010-048.xsl
+++ b/xsl/ConvSpec-010-048.xsl
@@ -289,7 +289,7 @@
           <bf:descriptionAuthentication>
             <bf:DescriptionAuthentication>
               <xsl:attribute name="rdf:about"><xsl:value-of select="concat($marcauthen,$encoded)"/></xsl:attribute>
-              <rdfs:label><xsl:value-of select="."/></rdfs:label>
+              <bf:code><xsl:value-of select="."/></bf:code>
             </bf:DescriptionAuthentication>
           </bf:descriptionAuthentication>
         </xsl:for-each>


### PR DESCRIPTION
Generate bf:code property, not rdfs:label. Fixes #116.