### PR TITLE
Don't generate bflc:relatorMatchKey property for Roles and Relations.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 --- 1.6.0-SNAPSHOT
 
+Don't generate bflc:relatorMatchKey property for Roles and Relations (https://github.com/lcnetdev/marc2bibframe2/issues/81)
 Update 008/18-20 conversion for visual materials (https://github.com/lcnetdev/marc2bibframe2/issues/147)
 
 --- 1.5.0 2019/06/12

--- a/metaproxy/filters-available/marc2bibframe2.xml
+++ b/metaproxy/filters-available/marc2bibframe2.xml
@@ -44,7 +44,6 @@
             <namespace prefix="rdf" href="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
             <namespace prefix="rdfs" href="http://www.w3.org/2000/01/rdf-schema#"/>
             <lookup xpath="//bf:Role[not(@rdf:about)] | //bflc:relation/rdfs:Resource[not(@rdf:about)]">
-              <key field="bflc:relatorMatchKey"/>
               <key field="rdfs:label"/>
               <server url="http://id.loc.gov/vocabulary/relators/label/%s" method="HEAD"/>
             </lookup>

--- a/record-conv.xml
+++ b/record-conv.xml
@@ -32,7 +32,6 @@
     <namespace prefix="rdf" href="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
     <namespace prefix="rdfs" href="http://www.w3.org/2000/01/rdf-schema#"/>
     <lookup xpath="//bf:Role[not(@rdf:about)] | //bflc:relation/bflc:Relation[not(@rdf:about)]">
-      <key field="bflc:relatorMatchKey"/>
       <key field="rdfs:label"/>
       <server url="http://id.loc.gov/vocabulary/relators/label/%s" method="HEAD"/>
     </lookup>

--- a/test/ConvSpec-1XX,6XX,7XX,8XX-names.xspec
+++ b/test/ConvSpec-1XX,6XX,7XX,8XX-names.xspec
@@ -15,7 +15,6 @@
     <x:expect label="1XX creates a bflc:PrimaryContribution" test="//bf:Work[1]/bf:contribution[1]/bf:Contribution/rdf:type/@rdf:resource = 'http://id.loc.gov/ontologies/bflc/PrimaryContribution'"/>
     <x:expect label="Name field with $e, $j, or $4 becomes a bf:Contribution" test="//bf:Work[1]/bf:contribution[2]/bf:Contribution/bf:agent/bf:Agent/rdfs:label = 'Hecht, Ben, 1893-1964,'"/>
     <x:expect label="...$e/$j become bf:role properties with blank bf:Role node" test="count(//bf:Work[1]/bf:contribution[2]/bf:Contribution/bf:role) = 5"/>
-    <x:expect label="...with a bflc:relatorMatchKey property for active conversion" test="//bf:Work[1]/bf:contribution[2]/bf:Contribution/bf:role[1]/bf:Role/bflc:relatorMatchKey = 'writing'"/>
     <x:expect label="...$4 becomes bf:role/bf:Role property with URI" test="//bf:Work[1]/bf:contribution[3]/bf:Contribution/bf:role[1]/bf:Role/@rdf:about = 'http://id.loc.gov/vocabulary/relators/prf'"/>
     <x:expect label="...$4 with URI becomes URI of Role" test="//bf:Work[1]/bf:contribution[3]/bf:Contribution/bf:role[3]/bf:Role/@rdf:about = 'http://id.loc.gov/vocabulary/relators/adi'"/>
     <x:expect label="...otherwise role of  bf:Contribution is ctb" test="//bf:Work[1]/bf:contribution[1]/bf:Contribution/bf:role/bf:Role/@rdf:about = 'http://id.loc.gov/vocabulary/relators/ctb'"/>

--- a/test/marc2bibframe2.xspec
+++ b/test/marc2bibframe2.xspec
@@ -152,7 +152,6 @@
                 <bf:role>
                   <bf:Role>
                     <rdfs:label>ill.</rdfs:label>
-                    <bflc:relatorMatchKey>ill</bflc:relatorMatchKey>
                   </bf:Role>
                 </bf:role>
               </bf:Contribution>

--- a/xsl/ConvSpec-1XX,6XX,7XX,8XX-names.xsl
+++ b/xsl/ConvSpec-1XX,6XX,7XX,8XX-names.xsl
@@ -639,11 +639,6 @@
                         </xsl:if>
                         <xsl:value-of select="$vRole"/>
                       </rdfs:label>
-                      <bflc:relatorMatchKey>
-                        <xsl:call-template name="chopPunctuation">
-                          <xsl:with-param name="chopString"><xsl:value-of select="$vRole"/></xsl:with-param>
-                        </xsl:call-template>
-                      </bflc:relatorMatchKey>
                     </bf:Role>
                   </bf:role>
                 </xsl:when>
@@ -658,11 +653,6 @@
                             </xsl:if>
                             <xsl:value-of select="$vRole"/>
                           </rdfs:label>
-                          <bflc:relatorMatchKey>
-                            <xsl:call-template name="chopPunctuation">
-                              <xsl:with-param name="chopString"><xsl:value-of select="$vRole"/></xsl:with-param>
-                            </xsl:call-template>
-                          </bflc:relatorMatchKey>
                         </bflc:Relation>
                       </bflc:relation>
                       <xsl:if test="$pRelatedTo != ''">
@@ -699,11 +689,6 @@
                         </xsl:if>
                         <xsl:value-of select="normalize-space(substring-before($roleString,' and'))"/>
                       </rdfs:label>
-                      <bflc:relatorMatchKey>
-                        <xsl:call-template name="chopPunctuation">
-                          <xsl:with-param name="chopString"><xsl:value-of select="$vRole"/></xsl:with-param>
-                        </xsl:call-template>
-                      </bflc:relatorMatchKey>
                     </bf:Role>
                   </bf:role>
                 </xsl:when>
@@ -718,11 +703,6 @@
                             </xsl:if>
                             <xsl:value-of select="$vRole"/>
                           </rdfs:label>
-                          <bflc:relatorMatchKey>
-                            <xsl:call-template name="chopPunctuation">
-                              <xsl:with-param name="chopString"><xsl:value-of select="$vRole"/></xsl:with-param>
-                            </xsl:call-template>
-                          </bflc:relatorMatchKey>
                         </bflc:Relation>
                       </bflc:relation>
                       <xsl:if test="$pRelatedTo != ''">
@@ -757,11 +737,6 @@
                         </xsl:if>
                         <xsl:value-of select="normalize-space(substring-before($roleString,'&amp;'))"/>
                       </rdfs:label>
-                      <bflc:relatorMatchKey>
-                        <xsl:call-template name="chopPunctuation">
-                          <xsl:with-param name="chopString"><xsl:value-of select="$vRole"/></xsl:with-param>
-                        </xsl:call-template>
-                      </bflc:relatorMatchKey>
                     </bf:Role>
                   </bf:role>
                 </xsl:when>
@@ -776,11 +751,6 @@
                             </xsl:if>
                             <xsl:value-of select="$vRole"/>
                           </rdfs:label>
-                          <bflc:relatorMatchKey>
-                            <xsl:call-template name="chopPunctuation">
-                              <xsl:with-param name="chopString"><xsl:value-of select="$vRole"/></xsl:with-param>
-                            </xsl:call-template>
-                          </bflc:relatorMatchKey>
                         </bflc:Relation>
                       </bflc:relation>
                       <xsl:if test="$pRelatedTo != ''">
@@ -813,11 +783,6 @@
                       </xsl:if>
                       <xsl:value-of select="normalize-space($roleString)"/>
                     </rdfs:label>
-                    <bflc:relatorMatchKey>
-                      <xsl:call-template name="chopPunctuation">
-                        <xsl:with-param name="chopString"><xsl:value-of select="normalize-space($roleString)"/></xsl:with-param>
-                      </xsl:call-template>
-                    </bflc:relatorMatchKey>
                   </bf:Role>
                 </bf:role>
               </xsl:when>
@@ -832,11 +797,6 @@
                             </xsl:if>
                             <xsl:value-of select="normalize-space($roleString)"/>
                           </rdfs:label>
-                          <bflc:relatorMatchKey>
-                            <xsl:call-template name="chopPunctuation">
-                              <xsl:with-param name="chopString"><xsl:value-of select="normalize-space($roleString)"/></xsl:with-param>
-                            </xsl:call-template>
-                          </bflc:relatorMatchKey>
                         </bflc:Relation>
                       </bflc:relation>
                       <xsl:if test="$pRelatedTo != ''">


### PR DESCRIPTION
The property was minted as a workaround for matching labels using the LC label service for relators. It is no longer needed. Resolves #81.