### PR TITLE
Update MARC 043 conversion: $b/$c generate rdf:value, not rdfs:label.

### DIFF
--- a/test/ConvSpec-010-048.xspec
+++ b/test/ConvSpec-010-048.xspec
@@ -212,9 +212,9 @@
   <x:scenario label="043 - GEOGRAPHIC AREA CODE">
     <x:context href="data/ConvSpec-010-048/marc.xml"/>
     <x:expect label="$a creates a geographicCoverage property of the Work" test="//bf:Work/bf:geographicCoverage[1]/bf:GeographicCoverage/@rdf:about = 'http://id.loc.gov/vocabulary/geographicAreas/s-bl'"/>
-    <x:expect label="$b creates a geographicCoverage property of the Work" test="//bf:Work/bf:geographicCoverage[2]/bf:GeographicCoverage/rdfs:label = 's-bl-ba'"/>
+    <x:expect label="$b creates a geographicCoverage property of the Work" test="//bf:Work/bf:geographicCoverage[2]/bf:GeographicCoverage/rdf:value = 's-bl-ba'"/>
     <x:expect label="...with the source of the GeographicCoverage from $2" test="//bf:Work/bf:geographicCoverage[2]/bf:GeographicCoverage/bf:source/bf:Source/rdfs:label = 'BlRjBN'"/>
-    <x:expect label="$c creates a geographicCoverage property of the Work" test="//bf:Work/bf:geographicCoverage[3]/bf:GeographicCoverage/rdfs:label = 'us'"/>
+    <x:expect label="$c creates a geographicCoverage property of the Work" test="//bf:Work/bf:geographicCoverage[3]/bf:GeographicCoverage/rdf:value = 'us'"/>
     <x:expect label="...with source labelled 'ISO 3166'" test="//bf:Work/bf:geographicCoverage[3]/bf:GeographicCoverage/bf:source/bf:Source/rdfs:label = 'ISO 3166'"/>
   </x:scenario>
   

--- a/xsl/ConvSpec-010-048.xsl
+++ b/xsl/ConvSpec-010-048.xsl
@@ -662,7 +662,7 @@
                   <xsl:attribute name="rdf:about"><xsl:value-of select="concat($geographicAreas,$encoded)"/></xsl:attribute>
                 </xsl:when>
                 <xsl:when test="@code='b' or @code='c'">
-                  <rdfs:label><xsl:value-of select="."/></rdfs:label>
+                  <rdf:value><xsl:value-of select="."/></rdf:value>
                   <xsl:choose>
                     <xsl:when test="@code='c'">
                       <bf:source>


### PR DESCRIPTION
Resolves #153.