### PR TITLE
Update MARC 530 conversion.

### DIFF
--- a/test/ConvSpec-490-510-530to535-Links.xspec
+++ b/test/ConvSpec-490-510-530to535-Links.xspec
@@ -34,7 +34,6 @@
     <x:expect label="...and an instanceOf property" test="//bf:Work[1]/bf:hasInstance[1]/bf:Instance/bf:instanceOf/@rdf:resource = 'http://example.org/1#Work'"/>
     <x:expect label="...and a title property" test="//bf:Work[1]/bf:hasInstance[1]/bf:Instance/bf:title/bf:Title/rdfs:label = 'Ole Lukøie /'"/>
     <x:expect label="530 creates a otherPhysicalFormat property of the Instance" test="//bf:Instance[1]/bf:otherPhysicalFormat/@rdf:resource = 'http://example.org/1#Instance530-6'"/>
-    <x:expect label="...and an otherPhysicalFormat property of the hasInstance/Instance" test="//bf:Work[1]/bf:hasInstance[1]/bf:Instance/bf:otherPhysicalFormat/@rdf:resource = 'http://example.org/1#Instance'"/>
     <x:expect label="$a creates a note property of the hasInstance/Instance" test="//bf:Work[1]/bf:hasInstance[1]/bf:Instance/bf:note[1]/bf:Note/rdfs:label = 'Available in microfilm'"/>
     <x:expect label="$b creates an acquisitionSource/AcquisitionSource property of the hasInstance/Instance" test="//bf:Work[1]/bf:hasInstance[1]/bf:Instance/bf:acquisitionSource/bf:AcquisitionSource/rdfs:label = 'National Archives'"/>
     <x:expect label="$c creates an acquisitionTerms property of the hasInstance/Instance" test="//bf:Work[1]/bf:hasInstance[1]/bf:Instance/bf:acquisitionTerms = 'Standing order account required'"/>

--- a/xsl/ConvSpec-490-510-530to535-Links.xsl
+++ b/xsl/ConvSpec-490-510-530to535-Links.xsl
@@ -208,9 +208,6 @@
     <xsl:variable name="vXmlLang"><xsl:apply-templates select="." mode="xmllang"/></xsl:variable>
     <xsl:choose>
       <xsl:when test="$serialization = 'rdfxml'">
-        <bf:otherPhysicalFormat>
-          <xsl:attribute name="rdf:resource"><xsl:value-of select="$recordid"/>#Instance</xsl:attribute>
-        </bf:otherPhysicalFormat>
         <xsl:for-each select="marc:subfield[@code='a']">
           <bf:note>
             <bf:Note>


### PR DESCRIPTION
Remove otherPhysicalFormat property from generated (skeletal) Instance. Better alignment with 776 conversion; better pattern to allow for reverse conversion.