### PR TITLE
Update conversion for 586.

### DIFF
--- a/test/ConvSpec-5XX.xspec
+++ b/test/ConvSpec-5XX.xspec
@@ -263,16 +263,14 @@
   
   <x:scenario label="586 - AWARDS NOTE">
     <x:context href="data/ConvSpec-5XX/marc.xml"/>
-    <x:expect label="586 creates a note/Note property of the Instance with noteType 'award'" test="//bf:Instance[1]/bf:note[15]/bf:Note/bf:noteType = 'award'"/>
-    <x:expect label="$a creates an rdfs:label property of the Note" test="//bf:Instance[1]/bf:note[15]/bf:Note/rdfs:label = 'National Book Award, 1981'"/>
-    <x:expect label="$3 creates a bflc:appliesTo property of the Note" test="//bf:Instance[1]/bf:note[15]/bf:Note/bflc:appliesTo/bflc:AppliesTo/rdfs:label = 'Accompanying material'"/>
+    <x:expect label="$a creates an awards property of the Instance" test="//bf:Instance[1]/bf:awards = 'National Book Award, 1981'"/>
   </x:scenario>
   
   <x:scenario label="588 - SOURCE OF DESCRIPTION NOTE">
     <x:context href="data/ConvSpec-5XX/marc.xml"/>
-    <x:expect label="588 creates a note/Note property of the Instance with noteType 'description source'" test="//bf:Instance[1]/bf:note[16]/bf:Note/bf:noteType = 'description source'"/>
-    <x:expect label="$a creates an rdfs:label property of the Note" test="//bf:Instance[1]/bf:note[16]/bf:Note/rdfs:label = 'Publication to be resumed by F&amp;W Publications, Inc.in Oct. 2009.'"/>
-    <x:expect label="$5 creates a bflc:applicableInstitution property of the Note" test="//bf:Instance[1]/bf:note[16]/bf:Note/bflc:applicableInstitution/bf:Agent/bf:code = 'EZB'"/>
+    <x:expect label="588 creates a note/Note property of the Instance with noteType 'description source'" test="//bf:Instance[1]/bf:note[15]/bf:Note/bf:noteType = 'description source'"/>
+    <x:expect label="$a creates an rdfs:label property of the Note" test="//bf:Instance[1]/bf:note[15]/bf:Note/rdfs:label = 'Publication to be resumed by F&amp;W Publications, Inc.in Oct. 2009.'"/>
+    <x:expect label="$5 creates a bflc:applicableInstitution property of the Note" test="//bf:Instance[1]/bf:note[15]/bf:Note/bflc:applicableInstitution/bf:Agent/bf:code = 'EZB'"/>
   </x:scenario>
 
 </x:description>

--- a/test/ConvSpec-880.xspec
+++ b/test/ConvSpec-880.xspec
@@ -105,8 +105,8 @@
     <x:expect label="$6 580 creates a note property of the Work" test="//bf:Work[1]/bf:note[1]/bf:Note/rdfs:label = 'Формы часть Frances Benjamin Johnston Collection.'"/>
     <x:expect label="$6 581 creates a note property of the Instance" test="//bf:Instance[1]/bf:note[16]/bf:Note/rdfs:label = 'Инвентаризация американской скульптуры: ксерокопия. 1982.'"/>
     <x:expect label="$6 585 creates a note property of the Instance" test="//bf:Instance[1]/bf:note[17]/bf:Note/rdfs:label = 'Выставлены: &quot;Видения City &amp; Country: эстампов и фотографий девятнадцатом веке во Франции&quot;, организованной Ворчестер художественного музея и Американской федерации искусств, 1982.'"/>
-    <x:expect label="$6 586 creates a note property of the Instance" test="//bf:Instance[1]/bf:note[18]/bf:Note/rdfs:label = 'Национальная книжная премия, 1981'"/>
-    <x:expect label="$6 588 creates a note property of the Instance" test="//bf:Instance[1]/bf:note[19]/bf:Note/rdfs:label = 'Том 2.'"/>
+    <x:expect label="$6 586 creates an awards property of the Instance" test="//bf:Instance[1]/bf:awards = 'Национальная книжная премия, 1981'"/>
+    <x:expect label="$6 588 creates a note property of the Instance" test="//bf:Instance[1]/bf:note[18]/bf:Note/rdfs:label = 'Том 2.'"/>
     <x:expect label="$6 600,610,611 creates a subject/Topic or subject/Work property of the Work" test="//bf:Work[1]/bf:subject[2]/bf:Topic/madsrdf:authoritativeLabel = 'семьи Кларк--Фантастика.'"/>
     <x:expect label="$6 630 creates a subject/Work property of the Work" test="//bf:Work[1]/bf:subject[3]/bf:Work/madsrdf:authoritativeLabel = 'украинский журнал'"/>
     <x:expect label="$6 648 creates a subject/Temporal property of the Work" test="//bf:Work[1]/bf:subject[4]/bf:Temporal/rdfs:label = 'Доисторические времена'"/>

--- a/xsl/ConvSpec-5XX.xsl
+++ b/xsl/ConvSpec-5XX.xsl
@@ -447,7 +447,7 @@
                                        marc:datafield[@tag='547'] | marc:datafield[@tag='550'] |
                                        marc:datafield[@tag='555'] | marc:datafield[@tag='556'] |
                                        marc:datafield[@tag='581'] | marc:datafield[@tag='585'] |
-                                       marc:datafield[@tag='586'] | marc:datafield[@tag='588']">
+                                       marc:datafield[@tag='588']">
     <xsl:param name="serialization" select="'rdfxml'"/>
     <xsl:apply-templates select="." mode="instanceNote5XX">
       <xsl:with-param name="serialization" select="$serialization"/>
@@ -646,6 +646,30 @@
     </xsl:choose>
   </xsl:template>
   
+  <xsl:template match="marc:datafield[@tag='586']" mode="instance">
+    <xsl:param name="serialization" select="'rdfxml'"/>
+    <xsl:apply-templates select="." mode="instance586">
+      <xsl:with-param name="serialization" select="$serialization"/>
+    </xsl:apply-templates>
+  </xsl:template>
+
+  <xsl:template match="marc:datafield[@tag='586' or @tag='880']" mode="instance586">
+    <xsl:param name="serialization" select="'rdfxml'"/>
+    <xsl:variable name="vXmlLang"><xsl:apply-templates select="." mode="xmllang"/></xsl:variable>
+    <xsl:choose>
+      <xsl:when test="$serialization='rdfxml'">
+        <xsl:for-each select="marc:subfield[@code='a']">
+          <bf:awards>
+            <xsl:if test="$vXmlLang != ''">
+              <xsl:attribute name="xml:lang"><xsl:value-of select="$vXmlLang"/></xsl:attribute>
+            </xsl:if>
+            <xsl:value-of select="."/>
+          </bf:awards>
+        </xsl:for-each>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
   <xsl:template match="marc:datafield" mode="instanceNote5XX">
     <xsl:param name="serialization" select="'rdfxml'"/>
     <xsl:param name="pNoteType"/>
@@ -694,7 +718,6 @@
           </xsl:choose>
         </xsl:when>
         <xsl:when test="$vTag='585'">exhibition</xsl:when>
-        <xsl:when test="$vTag='586'">award</xsl:when>
         <xsl:when test="$vTag='588'">description source</xsl:when>
       </xsl:choose>
     </xsl:variable>

--- a/xsl/ConvSpec-880.xsl
+++ b/xsl/ConvSpec-880.xsl
@@ -466,8 +466,7 @@
                       $tag='515' or $tag='516' or $tag='536' or
                       $tag='544' or $tag='545' or $tag='547' or
                       $tag='550' or $tag='555' or $tag='556' or
-                      $tag='581' or $tag='585' or $tag='586' or
-                      $tag='588'">
+                      $tag='581' or $tag='585' or $tag='588'">
         <xsl:apply-templates select="." mode="instanceNote5XX">
           <xsl:with-param name="serialization" select="$serialization"/>
         </xsl:apply-templates>
@@ -517,6 +516,11 @@
       </xsl:when>
       <xsl:when test="$tag='540'">
         <xsl:apply-templates select="." mode="instance540">
+          <xsl:with-param name="serialization" select="$serialization"/>
+        </xsl:apply-templates>
+      </xsl:when>
+      <xsl:when test="$tag='586'">
+        <xsl:apply-templates select="." mode="instance586">
           <xsl:with-param name="serialization" select="$serialization"/>
         </xsl:apply-templates>
       </xsl:when>


### PR DESCRIPTION
586 should create bf:awards property of the Instance, not a note. Missed spec update in v1.5.