### PR TITLE
Create bf:generationDate property of bf:GenerationProcess

### DIFF
--- a/test/marc2bibframe2.xspec
+++ b/test/marc2bibframe2.xspec
@@ -9,6 +9,8 @@
                xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                stylesheet="../xsl/marc2bibframe2.xsl" xslt-version="1.0">
 
+  <x:param name="pGenerationDatestamp" select="'1970-01-01T00:00:00Z'"/>
+
   <x:import href="ConvSpec-LDR.xspec"/>
   <x:import href="ConvSpec-001-007.xspec"/>
   <x:import href="ConvSpec-006,008.xspec"/>
@@ -39,6 +41,7 @@
                 <bf:generationProcess>
                   <bf:GenerationProcess>
                     <rdfs:label>DLC marc2bibframe2 v1.6.0-SNAPSHOT</rdfs:label>
+                    <bf:generationDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1970-01-01T00:00:00Z</bf:generationDate>
                   </bf:GenerationProcess>
                 </bf:generationProcess>
                 <bf:status>
@@ -253,6 +256,7 @@
                 <bf:generationProcess>
                   <bf:GenerationProcess>
                     <rdfs:label>DLC marc2bibframe2 v1.6.0-SNAPSHOT</rdfs:label>
+                    <bf:generationDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1970-01-01T00:00:00Z</bf:generationDate>
                   </bf:GenerationProcess>
                 </bf:generationProcess>
                 <bf:status>
@@ -495,6 +499,7 @@
                 <bf:generationProcess>
                   <bf:GenerationProcess>
                     <rdfs:label>DLC marc2bibframe2 v1.6.0-SNAPSHOT</rdfs:label>
+                    <bf:generationDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1970-01-01T00:00:00Z</bf:generationDate>
                   </bf:GenerationProcess>
                 </bf:generationProcess>
                 <bf:status>
@@ -811,6 +816,7 @@
                 <bf:generationProcess>
                   <bf:GenerationProcess>
                     <rdfs:label>DLC marc2bibframe2 v1.6.0-SNAPSHOT</rdfs:label>
+                    <bf:generationDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1970-01-01T00:00:00Z</bf:generationDate>
                   </bf:GenerationProcess>
                 </bf:generationProcess>
                 <bf:status>
@@ -1168,6 +1174,10 @@
   <x:scenario label="Generation Process">
     <x:context href="data/marc.xml"/>
     <x:expect label="Work/adminMetadata/AdminMetadata should have generationProcess property" test="starts-with(//bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:generationProcess/bf:GenerationProcess/rdfs:label,'DLC marc2bibframe2')"/>
+    <x:expect label="GenerationProcess should have a generationDate property if available"
+              test="//bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:generationProcess/bf:GenerationProcess/bf:generationDate = '1970-01-01T00:00:00Z'"/>
+    <x:expect label="...and a datatype"
+              test="//bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:generationProcess/bf:GenerationProcess/bf:generationDate/@rdf:datatype = 'http://www.w3.org/2001/XMLSchema#dateTime'"/>
   </x:scenario>
 
 </x:description>

--- a/xsl/marc2bibframe2.xsl
+++ b/xsl/marc2bibframe2.xsl
@@ -8,7 +8,8 @@
                 xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:date="http://exslt.org/dates-and-times"
-                extension-element-prefixes="date"
+                xmlns:fn="http://www.w3.org/2005/xpath-function"
+                extension-element-prefixes="date fn"
                 exclude-result-prefixes="xsl marc">
 
   <xsl:output encoding="UTF-8" method="xml" indent="yes"/>
@@ -56,9 +57,14 @@
       available
   -->
   <xsl:param name="pGenerationDatestamp">
-    <xsl:if test="function-available('date:date-time')">
-      <xsl:value-of select="date:date-time()"/>
-    </xsl:if>
+    <xsl:choose>
+      <xsl:when test="function-available('date:date-time')">
+        <xsl:value-of select="date:date-time()"/>
+      </xsl:when>
+      <xsl:when test="function-available('fn:current-dateTime')">
+        <xsl:value-of select="fn:current-dateTime()"/>
+      </xsl:when>
+    </xsl:choose>
   </xsl:param>
   
   <!-- Output serialization. Currently only "rdfxml" is supported -->
@@ -204,7 +210,13 @@
             <bf:AdminMetadata>
               <bf:generationProcess>
                 <bf:GenerationProcess>
-                  <rdfs:label>DLC marc2bibframe2 <xsl:value-of select="$vCurrentVersion"/><xsl:if test="$pGenerationDatestamp != ''">: <xsl:value-of select="$pGenerationDatestamp"/></xsl:if></rdfs:label>
+                  <rdfs:label>DLC marc2bibframe2 <xsl:value-of select="$vCurrentVersion"/></rdfs:label>
+                  <xsl:if test="$pGenerationDatestamp != ''">
+                    <bf:generationDate>
+                      <xsl:attribute name="rdf:datatype"><xsl:value-of select="concat($xs,'dateTime')"/></xsl:attribute>
+                      <xsl:value-of select="$pGenerationDatestamp"/>
+                    </bf:generationDate>
+                  </xsl:if>
                 </bf:GenerationProcess>
               </bf:generationProcess>
               <!-- pass fields through conversion specs for AdminMetadata properties -->


### PR DESCRIPTION
In bf:AdminMetadata, create a separate property for generation date rather than including in the bf:GenerationProcess label. Resolves #152.

Also add support for xpath-function (fn) extension elements. Allow use of fn:current-dateTime for the generation date.