### PR TITLE
Update conversion of MARC 510.

### DIFF
--- a/test/ConvSpec-490-510-530to535-Links.xspec
+++ b/test/ConvSpec-490-510-530to535-Links.xspec
@@ -20,11 +20,11 @@
   
   <x:scenario label="510 - CITATION/REFERENCES NOTE">
     <x:context href="data/ConvSpec-490-510-530to535-Links/marc.xml"/>
-    <x:expect label="ind 1 determines the Instance property to create with a Work object" test="count(//bf:Instance[1]/bf:references/bf:Work) = 1"/>
-    <x:expect label="$a creates a title property of the Work object" test="//bf:Instance[1]/bf:references/bf:Work/bf:title/bf:Title/bf:mainTitle = 'Index Medicus'"/>
-    <x:expect label="$b creates a note property of the Work object with noteType 'Coverage'" test="//bf:Instance[1]/bf:references/bf:Work/bf:note/bf:Note/bf:noteType[text()='Coverage']/parent::*/rdfs:label = 'v1n1, 1984-'"/>
-    <x:expect label="$c creates a note property of the Work object with noteType 'Location'" test="//bf:Instance[1]/bf:references/bf:Work/bf:note/bf:Note/bf:noteType[text()='Location']/parent::*/rdfs:label = 'p. 10, 50, and iii'"/>
-    <x:expect label="$x creates an identifiedBy/Issn property of the Work object" test="//bf:Instance[1]/bf:references/bf:Work/bf:identifiedBy/bf:Issn/rdf:value = '0019-3879'"/>
+    <x:expect label="ind 1 determines the Instance property to create with a Work object" test="count(//bf:Work[1]/bf:references/bf:Work) = 1"/>
+    <x:expect label="$a creates a title property of the Work object" test="//bf:Work[1]/bf:references/bf:Work/bf:title/bf:Title/bf:mainTitle = 'Index Medicus'"/>
+    <x:expect label="$b creates a note property of the Work object with noteType 'Coverage'" test="//bf:Work[1]/bf:references/bf:Work/bf:note/bf:Note/bf:noteType[text()='Coverage']/parent::*/rdfs:label = 'v1n1, 1984-'"/>
+    <x:expect label="$c creates a note property of the Work object with noteType 'Location'" test="//bf:Work[1]/bf:references/bf:Work/bf:note/bf:Note/bf:noteType[text()='Location']/parent::*/rdfs:label = 'p. 10, 50, and iii'"/>
+    <x:expect label="$x creates an identifiedBy/Issn property of the Work object" test="//bf:Work[1]/bf:references/bf:Work/bf:identifiedBy/bf:Issn/rdf:value = '0019-3879'"/>
   </x:scenario>
 
   <x:scenario label="530 - ADDITIONAL PHYSICAL FORM AVAILABLE NOTE">

--- a/test/ConvSpec-880.xspec
+++ b/test/ConvSpec-880.xspec
@@ -74,7 +74,7 @@
     <x:expect label="$6 506 creates a usageAndAccessPolicy property of the Instance" test="//bf:Instance[1]/bf:usageAndAccessPolicy[1]/bf:UsageAndAccessPolicy/rdfs:label = 'Классифицированная информация.'"/>
     <x:expect label="$6 507 creates a scale property of the Work" test="//bf:Work[1]/bf:scale[2]/bf:Scale/bf:note/bf:Note/rdfs:label = 'Перспектива карта не в масштабе.'"/>
     <x:expect label="$6 508 creates a credits property of the Instance" test="//bf:Instance[1]/bf:credits[1] = 'Музыка, Майкл Фишбейн; камера, Джордж Mo.'"/>
-    <x:expect label="$6 510 creates a bflc:indexedIn or bf:references property of the Instance" test="//bf:Instance[1]/bflc:indexedIn[1]/bf:Work/bf:title/bf:Title/bf:mainTitle = 'химический рефераты'"/>
+    <x:expect label="$6 510 creates a bflc:indexedIn or bf:references property of the Work" test="//bf:Work[1]/bflc:indexedIn[1]/bf:Work/bf:title/bf:Title/bf:mainTitle = 'химический рефераты'"/>
     <x:expect label="$6 511 creates a bf:credits property of the Instance" test="//bf:Instance[1]/bf:credits[2] = 'Джеки Гланвилл.'"/>
     <x:expect label="$6 513 creates a note property of the Instance" test="//bf:Instance[1]/bf:note[6]/bf:Note/rdfs:label = 'Ежеквартальный отчет технический прогресс; Январь-апрель 1, 1977.'"/>
     <x:expect label="$6 515 creates a note property of the Instance" test="//bf:Instance[1]/bf:note[7]/bf:Note/rdfs:label = 'Выпущенные в частях.'"/>

--- a/xsl/ConvSpec-490-510-530to535-Links.xsl
+++ b/xsl/ConvSpec-490-510-530to535-Links.xsl
@@ -43,6 +43,80 @@
     </xsl:if>
   </xsl:template>
   
+  <xsl:template match="marc:datafield[@tag='510']" mode="work">
+    <xsl:param name="serialization" select="'rdfxml'"/>
+    <xsl:apply-templates select="." mode="work510">
+      <xsl:with-param name="serialization" select="$serialization"/>
+    </xsl:apply-templates>
+  </xsl:template>
+
+  <xsl:template match="marc:datafield[@tag='510' or @tag='880']" mode="work510">
+    <xsl:param name="serialization" select="'rdfxml'"/>
+    <xsl:variable name="vXmlLang"><xsl:apply-templates select="." mode="xmllang"/></xsl:variable>
+    <xsl:variable name="vProperty">
+      <xsl:choose>
+        <xsl:when test="@ind1='0' or @ind1='1' or @ind1='2'">bflc:indexedIn</xsl:when>
+        <xsl:otherwise>bf:references</xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="$serialization = 'rdfxml'">
+        <xsl:element name="{$vProperty}">
+          <bf:Work>
+            <xsl:for-each select="marc:subfield[@code='a']">
+              <bf:title>
+                <bf:Title>
+                  <bf:mainTitle>
+                    <xsl:if test="$vXmlLang != ''">
+                      <xsl:attribute name="xml:lang"><xsl:value-of select="$vXmlLang"/></xsl:attribute>
+                    </xsl:if>
+                    <xsl:call-template name="chopPunctuation">
+                      <xsl:with-param name="chopString" select="."/>
+                      <xsl:with-param name="punctuation"><xsl:text>:,;/ </xsl:text></xsl:with-param>
+                    </xsl:call-template>
+                  </bf:mainTitle>
+                </bf:Title>
+              </bf:title>
+            </xsl:for-each>
+            <xsl:for-each select="marc:subfield[@code='b' or @code='c']">
+              <bf:note>
+                <bf:Note>
+                  <bf:noteType>
+                    <xsl:choose>
+                      <xsl:when test="@code='b'">Coverage</xsl:when>
+                      <xsl:when test="@code='c'">Location</xsl:when>
+                    </xsl:choose>
+                  </bf:noteType>
+                  <rdfs:label>
+                    <xsl:if test="$vXmlLang != ''">
+                      <xsl:attribute name="xml:lang"><xsl:value-of select="$vXmlLang"/></xsl:attribute>
+                    </xsl:if>
+                    <xsl:call-template name="chopPunctuation">
+                      <xsl:with-param name="chopString" select="."/>
+                      <xsl:with-param name="punctuation"><xsl:text>:,;/ </xsl:text></xsl:with-param>
+                    </xsl:call-template>
+                  </rdfs:label>
+                </bf:Note>
+              </bf:note>
+            </xsl:for-each>
+            <xsl:for-each select="marc:subfield[@code='x']">
+              <bf:identifiedBy>
+                <bf:Issn>
+                  <rdf:value>
+                    <xsl:call-template name="chopPunctuation">
+                      <xsl:with-param name="chopString" select="."/>
+                      <xsl:with-param name="punctuation"><xsl:text>:,;/ </xsl:text></xsl:with-param>
+                    </xsl:call-template>
+                  </rdf:value>
+                </bf:Issn>
+              </bf:identifiedBy>
+            </xsl:for-each>
+          </bf:Work>
+        </xsl:element>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
   <xsl:template match="marc:datafield[@tag='530' or @tag='533' or @tag='534']" mode="work">
     <xsl:param name="serialization" select="'rdfxml'"/>
     <xsl:param name="recordid"/>
@@ -678,80 +752,6 @@
     </xsl:for-each>
   </xsl:template>
   
-  <xsl:template match="marc:datafield[@tag='510']" mode="instance">
-    <xsl:param name="serialization" select="'rdfxml'"/>
-    <xsl:apply-templates select="." mode="instance510">
-      <xsl:with-param name="serialization" select="$serialization"/>
-    </xsl:apply-templates>
-  </xsl:template>
-
-  <xsl:template match="marc:datafield[@tag='510' or @tag='880']" mode="instance510">
-    <xsl:param name="serialization" select="'rdfxml'"/>
-    <xsl:variable name="vXmlLang"><xsl:apply-templates select="." mode="xmllang"/></xsl:variable>
-    <xsl:variable name="vProperty">
-      <xsl:choose>
-        <xsl:when test="@ind1='0' or @ind1='1' or @ind1='2'">bflc:indexedIn</xsl:when>
-        <xsl:otherwise>bf:references</xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-    <xsl:choose>
-      <xsl:when test="$serialization = 'rdfxml'">
-        <xsl:element name="{$vProperty}">
-          <bf:Work>
-            <xsl:for-each select="marc:subfield[@code='a']">
-              <bf:title>
-                <bf:Title>
-                  <bf:mainTitle>
-                    <xsl:if test="$vXmlLang != ''">
-                      <xsl:attribute name="xml:lang"><xsl:value-of select="$vXmlLang"/></xsl:attribute>
-                    </xsl:if>
-                    <xsl:call-template name="chopPunctuation">
-                      <xsl:with-param name="chopString" select="."/>
-                      <xsl:with-param name="punctuation"><xsl:text>:,;/ </xsl:text></xsl:with-param>
-                    </xsl:call-template>
-                  </bf:mainTitle>
-                </bf:Title>
-              </bf:title>
-            </xsl:for-each>
-            <xsl:for-each select="marc:subfield[@code='b' or @code='c']">
-              <bf:note>
-                <bf:Note>
-                  <bf:noteType>
-                    <xsl:choose>
-                      <xsl:when test="@code='b'">Coverage</xsl:when>
-                      <xsl:when test="@code='c'">Location</xsl:when>
-                    </xsl:choose>
-                  </bf:noteType>
-                  <rdfs:label>
-                    <xsl:if test="$vXmlLang != ''">
-                      <xsl:attribute name="xml:lang"><xsl:value-of select="$vXmlLang"/></xsl:attribute>
-                    </xsl:if>
-                    <xsl:call-template name="chopPunctuation">
-                      <xsl:with-param name="chopString" select="."/>
-                      <xsl:with-param name="punctuation"><xsl:text>:,;/ </xsl:text></xsl:with-param>
-                    </xsl:call-template>
-                  </rdfs:label>
-                </bf:Note>
-              </bf:note>
-            </xsl:for-each>
-            <xsl:for-each select="marc:subfield[@code='x']">
-              <bf:identifiedBy>
-                <bf:Issn>
-                  <rdf:value>
-                    <xsl:call-template name="chopPunctuation">
-                      <xsl:with-param name="chopString" select="."/>
-                      <xsl:with-param name="punctuation"><xsl:text>:,;/ </xsl:text></xsl:with-param>
-                    </xsl:call-template>
-                  </rdf:value>
-                </bf:Issn>
-              </bf:identifiedBy>
-            </xsl:for-each>
-          </bf:Work>
-        </xsl:element>
-      </xsl:when>
-    </xsl:choose>
-  </xsl:template>
-
   <xsl:template match="marc:datafield[@tag='530']" mode="instance">
     <xsl:param name="serialization" select="'rdfxml'"/>
     <xsl:param name="recordid"/>

--- a/xsl/ConvSpec-880.xsl
+++ b/xsl/ConvSpec-880.xsl
@@ -160,6 +160,11 @@
           <xsl:with-param name="serialization" select="$serialization"/>
         </xsl:apply-templates>
       </xsl:when>
+      <xsl:when test="$tag='510'">
+        <xsl:apply-templates select="." mode="work510">
+          <xsl:with-param name="serialization" select="$serialization"/>
+        </xsl:apply-templates>
+      </xsl:when>
       <xsl:when test="$tag='518'">
         <xsl:apply-templates select="." mode="work518">
           <xsl:with-param name="serialization" select="$serialization"/>
@@ -478,11 +483,6 @@
       </xsl:when>
       <xsl:when test="$tag='508' or $tag='511'">
         <xsl:apply-templates select="." mode="instanceCreditsNote">
-          <xsl:with-param name="serialization" select="$serialization"/>
-        </xsl:apply-templates>
-      </xsl:when>
-      <xsl:when test="$tag='510'">
-        <xsl:apply-templates select="." mode="instance510">
           <xsl:with-param name="serialization" select="$serialization"/>
         </xsl:apply-templates>
       </xsl:when>


### PR DESCRIPTION
MARC 510 should generate properties of the Work, not the instance. Fixes #160.