### PR TITLE
Update MARC 264 conversion.

### DIFF
--- a/test/ConvSpec-250-270.xspec
+++ b/test/ConvSpec-250-270.xspec
@@ -89,8 +89,10 @@
 
   <x:scenario label="264 - PRODUCTION, PUBLICATION, DISTRIBUTION, MANUFACTURE, AND COPYRIGHT NOTICE">
     <x:context href="data/ConvSpec-250-270/marc.xml"/>
-    <x:expect label="264 creates a provisionActivity or copyrightDate property of the Instance" test="count(//bf:Instance[1]/bf:provisionActivity) = 10"/>
+    <x:expect label="264 creates a provisionActivity or copyrightDate property of the Instance" test="count(//bf:Instance[1]/bf:provisionActivity) = 11"/>
     <x:expect label="...with resource class determined by ind2" test="//bf:Instance[1]/bf:provisionActivity[10]/bf:ProvisionActivity/rdf:type/@rdf:resource = 'http://id.loc.gov/ontologies/bibframe/Publication'"/>
+    <x:expect label="...do not create additional class for ProvisionActivity if it can't be determined"
+              test="count(//bf:Instance[1]/bf:provisionActivity[11]/bf:ProvisionActivity/rdf:type) = 0"/>
     <x:expect label="...and a provisionActivityStatement from $a $b $c in field order with a semicolon separating the parts if no other punctuation" test="//bf:Instance[1]/bf:provisionActivityStatement[4] = 'U.S. G.P.O. Washington : 1981-'"/>
     <x:expect label="ind1 = 3 creates a status property of the ProvisionActivity" test="//bf:Instance[1]/bf:provisionActivity[10]/bf:ProvisionActivity/bf:status/bf:Status/rdfs:label = 'current'"/>
     <x:expect label="$3 creates a bflc:appliesTo property of the ProvisionActivity" test="//bf:Instance[1]/bf:provisionActivity[10]/bf:ProvisionActivity/bflc:appliesTo/bflc:AppliesTo/rdfs:label = '1981-'"/>

--- a/test/data/ConvSpec-250-270/marc.xml
+++ b/test/data/ConvSpec-250-270/marc.xml
@@ -68,6 +68,11 @@
       <subfield code="a">Washington :</subfield>
       <subfield code="c">1981-</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2=" ">
+      <subfield code="a">Bendery :</subfield>
+      <subfield code="b">[publisher not identified],</subfield>
+      <subfield code="c">[2010]</subfield>
+    </datafield>
     <datafield tag="265" ind1=" " ind2=" ">
       <subfield code="a">U.S. Geological Survey, Reston, Va. 22091</subfield>
     </datafield>

--- a/xsl/ConvSpec-250-270.xsl
+++ b/xsl/ConvSpec-250-270.xsl
@@ -317,9 +317,11 @@
             <xsl:if test="marc:subfield[@code='a' or @code='b' or @code='c']">
               <bf:provisionActivity>
                 <bf:ProvisionActivity>
-                  <rdf:type>
-                    <xsl:attribute name="rdf:resource"><xsl:value-of select="concat($bf,$vProvisionActivity)"/></xsl:attribute>
-                  </rdf:type>
+                  <xsl:if test="$vProvisionActivity != ''">
+                    <rdf:type>
+                      <xsl:attribute name="rdf:resource"><xsl:value-of select="concat($bf,$vProvisionActivity)"/></xsl:attribute>
+                    </rdf:type>
+                  </xsl:if>
                   <xsl:if test="$vTag='260' or $vTag='264'">
                     <xsl:if test="@ind1 = '3'">
                       <bf:status>


### PR DESCRIPTION
Do not generate additional class for bf:ProvisionActivity if cannot be determined from ind2. Fixes #150.