### PR TITLE
Update Process 6 (Series) conversion.

### DIFF
--- a/test/ConvSpec-Process6-Series.xspec
+++ b/test/ConvSpec-Process6-Series.xspec
@@ -26,6 +26,10 @@
     <x:expect label="8XX $7 sets the rdf:type of the series Work" test="//bf:Work[3]/bf:hasSeries/bf:Work/rdf:type/@rdf:resource = 'http://id.loc.gov/ontologies/bibframe/Text'"/>
     <x:expect label="8XX $7 sets the issuance of the series Work" test="//bf:Work[3]/bf:hasSeries/bf:Work/bf:issuance/bf:Issuance/bf:code = 's'"/>
     <x:expect label="Subseries in 490 with repeated $a matches multiple 8XX" test="//bf:Work[4]/bf:hasSeries[2]/bf:Work/bf:identifiedBy/bf:Issn/rdf:value = '2345-6789'"/>
+    <x:expect label="Two 8XX, one 490 - second 8XX should generate seriesStatement property on Instance"
+              test="//bf:Instance[6]/bf:seriesStatement[2] = 'Zoku Teikoku bunko'"/>
+    <x:expect label="...and seriesEnumeration property"
+              test="//bf:Instance[6]/bf:seriesEnumeration[1] = 'dai 34-hen, etc.'"/>
     <x:expect label="Two 830s, one 490 with $x - Subseries in 490 with single $a matches first 8XX (recursion issue, plus added scenario)" test="//bf:Work[6]/bf:hasSeries[1]/bf:Work/bf:identifiedBy/bf:Issn/rdf:value = 'issn123456789'"/>
     <x:expect label="Obsolete 4XX fields treated like 8XX without 490 match" test="//bf:Work[5]/bf:hasSeries[1]/bf:Work/rdfs:label = 'Fernando, A. Denis N. Resource maps of Sri Lanka'"/>
   </x:scenario>

--- a/test/marc2bibframe2.xspec
+++ b/test/marc2bibframe2.xspec
@@ -1125,7 +1125,9 @@
               </bf:Note>
             </bf:note>
             <bf:dimensions>26 cm.</bf:dimensions>
-                    <bf:seriesStatement>A Joint publication in the Jossey-Bass public administration series, the Jossey-Bass nonprofit sector series, and the Jossey-Bass social and behavioral science series</bf:seriesStatement>
+            <bf:seriesStatement>A Joint publication in the Jossey-Bass public administration series, the Jossey-Bass nonprofit sector series, and the Jossey-Bass social and behavioral science series</bf:seriesStatement>
+            <bf:seriesStatement>Jossey-Bass nonprofit sector series.</bf:seriesStatement>
+            <bf:seriesStatement>Jossey-Bass social and behavioral science series.</bf:seriesStatement>
             <bf:supplementaryContent>
               <rdfs:Resource>
                 <bflc:locator rdf:resource="http://www.loc.gov/catdir/bios/wiley043/93048623.html"/>

--- a/xsl/ConvSpec-Process6-Series.xsl
+++ b/xsl/ConvSpec-Process6-Series.xsl
@@ -217,13 +217,22 @@
 
   <xsl:template match="marc:datafield[@tag='800' or @tag='810' or @tag='811' or @tag='830' or @tag='400' or @tag='410' or @tag='411' or @tag='440']" mode="instance">
     <xsl:param name="serialization" select="'rdfxml'"/>
+    <xsl:variable name="vCurrentPos">
+      <xsl:choose>
+        <xsl:when test="substring(@tag,1,1)='8'">
+          <xsl:value-of select="count(preceding-sibling::marc:datafield[@tag='800' or @tag='810' or @tag='811' or @tag='830']) + 1"/>
+        </xsl:when>
+      </xsl:choose>
+    </xsl:variable>
     <xsl:apply-templates select="." mode="instance8XX">
       <xsl:with-param name="serialization" select="$serialization"/>
+      <xsl:with-param name="pCurrentPos" select="$vCurrentPos"/>
     </xsl:apply-templates>
   </xsl:template>
 
   <xsl:template match="marc:datafield" mode="instance8XX">
     <xsl:param name="serialization" select="'rdfxml'"/>
+    <xsl:param name="pCurrentPos" select="1"/>
     <xsl:variable name="vXmlLang"><xsl:apply-templates select="." mode="xmllang"/></xsl:variable>
     <xsl:variable name="vTag">
       <xsl:choose>
@@ -231,7 +240,7 @@
         <xsl:otherwise><xsl:value-of select="@tag"/></xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
-    <xsl:if test="not(../marc:datafield[@tag='490' and @ind1 = '1']) or substring($vTag,1,1)='4' or @tag='880'">
+    <xsl:if test="count(../marc:datafield[@tag='490' and @ind1 = '1']) &lt; $pCurrentPos or substring($vTag,1,1)='4' or @tag='880'">
       <xsl:variable name="vStatement">
         <xsl:apply-templates mode="concat-nodes-space" select="marc:subfield[not(contains('vwx012345678',@code))]"/>
       </xsl:variable>


### PR DESCRIPTION
Additional 8XX fields that are not matched to 490s should generate seriesStatement and seriesEnumeration properties on the Instance. Fixes #164.