### PR TITLE
Add madsrdf namespace to all testing documents.

### DIFF
--- a/test/ConvSpec-001-007.xspec
+++ b/test/ConvSpec-001-007.xspec
@@ -6,6 +6,7 @@
                xmlns:marc="http://www.loc.gov/MARC21/slim"
                xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
                xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+               xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                stylesheet="../xsl/marc2bibframe2.xsl"
                xslt-version="1.0">
 

--- a/test/ConvSpec-006,008.xspec
+++ b/test/ConvSpec-006,008.xspec
@@ -6,6 +6,7 @@
                xmlns:marc="http://www.loc.gov/MARC21/slim"
                xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
                xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+               xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                stylesheet="../xsl/marc2bibframe2.xsl"
                xslt-version="1.0">
 

--- a/test/ConvSpec-010-048.xspec
+++ b/test/ConvSpec-010-048.xspec
@@ -6,6 +6,7 @@
                xmlns:marc="http://www.loc.gov/MARC21/slim"
                xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
                xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+               xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                stylesheet="../xsl/marc2bibframe2.xsl"
                xslt-version="1.0">
 

--- a/test/ConvSpec-050-088.xspec
+++ b/test/ConvSpec-050-088.xspec
@@ -6,6 +6,7 @@
                xmlns:marc="http://www.loc.gov/MARC21/slim"
                xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
                xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+               xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                stylesheet="../xsl/marc2bibframe2.xsl"
                xslt-version="1.0">
 

--- a/test/ConvSpec-200-247not240-Titles.xspec
+++ b/test/ConvSpec-200-247not240-Titles.xspec
@@ -6,6 +6,7 @@
                xmlns:marc="http://www.loc.gov/MARC21/slim"
                xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
                xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+               xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                stylesheet="../xsl/marc2bibframe2.xsl" xslt-version="1.0">
 
   <x:scenario label="210 - ABBREVIATED TITLE">

--- a/test/ConvSpec-240andX30-UnifTitle.xspec
+++ b/test/ConvSpec-240andX30-UnifTitle.xspec
@@ -5,6 +5,7 @@
                xmlns:marc="http://www.loc.gov/MARC21/slim"
                xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
                xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+               xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                stylesheet="../xsl/marc2bibframe2.xsl" xslt-version="1.0">
 
   <x:scenario label="Uniform title bf:Title creation">

--- a/test/ConvSpec-250-270.xspec
+++ b/test/ConvSpec-250-270.xspec
@@ -6,6 +6,7 @@
                xmlns:marc="http://www.loc.gov/MARC21/slim"
                xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
                xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+               xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                stylesheet="../xsl/marc2bibframe2.xsl"
                xslt-version="1.0">
 

--- a/test/ConvSpec-3XX.xspec
+++ b/test/ConvSpec-3XX.xspec
@@ -6,6 +6,7 @@
                xmlns:marc="http://www.loc.gov/MARC21/slim"
                xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
                xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+               xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                stylesheet="../xsl/marc2bibframe2.xsl"
                xslt-version="1.0">
 

--- a/test/ConvSpec-490-510-530to535-Links.xspec
+++ b/test/ConvSpec-490-510-530to535-Links.xspec
@@ -6,6 +6,7 @@
                xmlns:marc="http://www.loc.gov/MARC21/slim"
                xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
                xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+               xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                stylesheet="../xsl/marc2bibframe2.xsl"
                xslt-version="1.0">
 

--- a/test/ConvSpec-5XX.xspec
+++ b/test/ConvSpec-5XX.xspec
@@ -6,6 +6,7 @@
                xmlns:marc="http://www.loc.gov/MARC21/slim"
                xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
                xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+               xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                stylesheet="../xsl/marc2bibframe2.xsl"
                xslt-version="1.0">
 

--- a/test/ConvSpec-LDR.xspec
+++ b/test/ConvSpec-LDR.xspec
@@ -6,6 +6,7 @@
                xmlns:marc="http://www.loc.gov/MARC21/slim"
                xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
                xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+               xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                stylesheet="../xsl/marc2bibframe2.xsl"
                xslt-version="1.0">
 

--- a/test/ConvSpec-Process6-Series.xspec
+++ b/test/ConvSpec-Process6-Series.xspec
@@ -6,6 +6,7 @@
                xmlns:marc="http://www.loc.gov/MARC21/slim"
                xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
                xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+               xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                stylesheet="../xsl/marc2bibframe2.xsl"
                xslt-version="1.0">
 


### PR DESCRIPTION
Required due to update in xspec (https://github.com/xspec/xspec/pull/1116).