### PR TITLE
Update to processing of $0 and $2

### DIFF
--- a/test/ConvSpec-010-048.xspec
+++ b/test/ConvSpec-010-048.xspec
@@ -83,7 +83,7 @@
     <x:expect label="$d creates a note property of the Identifier" test="//bf:Instance[1]/bf:identifiedBy[15]/bf:Ean/bf:note/bf:Note/rdfs:label = '51000'"/>
     <x:expect label="$q creates a qualifier property of the Identifier" test="//bf:Instance[1]/bf:identifiedBy[14]/bf:Ismn/bf:qualifier[2] = 'sewn'"/>
     <x:expect label="$z creates a status/Status property of the Identifier with rdfs:label 'invalid'" test="//bf:Instance[1]/bf:identifiedBy[13]/bf:Upc/bf:status/bf:Status/rdfs:label = 'invalid'"/>
-    <x:expect label="$2 creates a source/Source property of the Identifier if the Identifier is not subclassed" test="//bf:Instance[1]/bf:identifiedBy[18]/bf:Identifier/bf:source/bf:Source/rdfs:label = 'sample'"/>
+    <x:expect label="$2 creates a source/Source property of the Identifier if the Identifier is not subclassed" test="//bf:Instance[1]/bf:identifiedBy[18]/bf:Identifier/bf:source/bf:Source/bf:code = 'sample'"/>
   </x:scenario>
 
   <x:scenario label="025 - OVERSEAS ACQUISITION NUMBER">
@@ -213,9 +213,9 @@
     <x:context href="data/ConvSpec-010-048/marc.xml"/>
     <x:expect label="$a creates a geographicCoverage property of the Work" test="//bf:Work/bf:geographicCoverage[1]/bf:GeographicCoverage/@rdf:about = 'http://id.loc.gov/vocabulary/geographicAreas/s-bl'"/>
     <x:expect label="$b creates a geographicCoverage property of the Work" test="//bf:Work/bf:geographicCoverage[2]/bf:GeographicCoverage/rdf:value = 's-bl-ba'"/>
-    <x:expect label="...with the source of the GeographicCoverage from $2" test="//bf:Work/bf:geographicCoverage[2]/bf:GeographicCoverage/bf:source/bf:Source/rdfs:label = 'BlRjBN'"/>
+    <x:expect label="...with the source of the GeographicCoverage from $2" test="//bf:Work/bf:geographicCoverage[2]/bf:GeographicCoverage/bf:source/bf:Source/bf:code = 'BlRjBN'"/>
     <x:expect label="$c creates a geographicCoverage property of the Work" test="//bf:Work/bf:geographicCoverage[3]/bf:GeographicCoverage/rdf:value = 'us'"/>
-    <x:expect label="...with source labelled 'ISO 3166'" test="//bf:Work/bf:geographicCoverage[3]/bf:GeographicCoverage/bf:source/bf:Source/rdfs:label = 'ISO 3166'"/>
+    <x:expect label="...with source labelled 'ISO 3166'" test="//bf:Work/bf:geographicCoverage[3]/bf:GeographicCoverage/bf:source/bf:Source/bf:code = 'ISO 3166'"/>
   </x:scenario>
   
   <x:scenario label="045 - TIME PERIOD OF CONTENT">

--- a/test/ConvSpec-050-088.xspec
+++ b/test/ConvSpec-050-088.xspec
@@ -80,7 +80,7 @@
     <x:context href="data/ConvSpec-050-088/marc.xml"/>
     <x:expect label="072 creates a subject property of the Work" test="count(//bf:Work[1]/bf:subject/bf:Topic) = 3"/>
     <x:expect label="$ax creates a code property of the Topic" test="//bf:Work[1]/bf:subject[2]/bf:Topic/bf:code = 'Z1 .630'"/>
-    <x:expect label="$2 creates source property of the Topic" test="//bf:Work[1]/bf:subject[2]/bf:Topic/bf:source/bf:Source/rdfs:label = 'mesh'"/>
+    <x:expect label="$2 creates source property of the Topic" test="//bf:Work[1]/bf:subject[2]/bf:Topic/bf:source/bf:Source/bf:code = 'mesh'"/>
     <x:expect label="...with URI if $2 = 'bisacsh'" test="//bf:Work[1]/bf:subject[3]/bf:Topic/bf:source/bf:Source/@rdf:about = 'http://id.loc.gov/vocabulary/classSchemes/bisacsh'"/>
     <x:expect label="ind2 = '0' creates 'agricola' source property of the Topic" test="//bf:Work[1]/bf:subject[1]/bf:Topic/bf:source/bf:Source/@rdf:about = 'http://id.loc.gov/vocabulary/classSchemes/agricola'"/>
   </x:scenario>
@@ -99,7 +99,7 @@
     <x:expect label="$a creates the classificationPortion of the ClassificationDdc" test="//bf:Work[1]/bf:classification[7]/bf:ClassificationDdc/bf:classificationPortion = '975.5/4252/00222'"/>
     <x:expect label="$b creates an itemPortion of the ClassificationDdc" test="//bf:Work[1]/bf:classification[7]/bf:ClassificationDdc/bf:itemPortion = 'Wor'"/>
     <x:expect label="$q creates an assigner property" test="//bf:Work[1]/bf:classification[8]/bf:ClassificationDdc/bf:assigner/bf:Agent/rdfs:label = 'DE-101b'"/>
-    <x:expect label="$2 creates a source property of the ClassificationDdc" test="//bf:Work[1]/bf:classification[7]/bf:ClassificationDdc/bf:source/bf:Source/rdfs:label = '22'"/>
+    <x:expect label="$2 creates a source property of the ClassificationDdc" test="//bf:Work[1]/bf:classification[7]/bf:ClassificationDdc/bf:source/bf:Source/bf:code = '22'"/>
     <x:expect label="ind1 creates an edition property of the ClassificationDdc" test="//bf:Work[1]/bf:classification[7]/bf:ClassificationDdc/bf:edition = 'full'"/>
     <x:expect label="ind2 can set an assigner property of the ClassificationDdc" test="//bf:Work[1]/bf:classification[7]/bf:ClassificationDdc/bf:assigner/bf:Agent/@rdf:about = 'http://id.loc.gov/vocabulary/organizations/dlc'"/>
   </x:scenario>
@@ -110,7 +110,7 @@
     <x:expect label="$a creates the classificationPortion of the Classification" test="//bf:Work[1]/bf:classification[9]/bf:Classification/bf:classificationPortion = 'KB112.554'"/>
     <x:expect label="$b creates an itemPortion of the Classification" test="//bf:Work[1]/bf:classification[9]/bf:Classification/bf:itemPortion = 'U62 1980'"/>
     <x:expect label="$q creates an assigner property of the Classification" test="//bf:Work[1]/bf:classification[9]/bf:Classification/bf:assigner/bf:Agent/rdfs:label = 'DE-101'"/>
-    <x:expect label="$2 creates a source property of the Classification" test="//bf:Work[1]/bf:classification[9]/bf:Classification/bf:source/bf:Source/rdfs:label = 'sdnb'"/>
+    <x:expect label="$2 creates a source property of the Classification" test="//bf:Work[1]/bf:classification[9]/bf:Classification/bf:source/bf:Source/bf:code = 'sdnb'"/>
     <x:expect label="First $0 that is a URI sets the URI of the Classification" test="//bf:Work[1]/bf:classification[9]/bf:Classification/@rdf:about = 'http://example.org/KB112.554'"/>
     <x:expect label="Additional $0s create identifiedBy properties of the Classification" test="//bf:Work[1]/bf:classification[9]/bf:Classification/bf:identifiedBy[1]/bf:Identifier/rdf:value/@rdf:resource = 'http://example.com/KB112.554'"/>
   </x:scenario>

--- a/test/ConvSpec-1XX,6XX,7XX,8XX-names.xspec
+++ b/test/ConvSpec-1XX,6XX,7XX,8XX-names.xspec
@@ -38,7 +38,7 @@
     <x:expect label="bf:Agent/bflc:nameMarcKey generation" test="//bf:Work[1]/bf:contribution[1]/bf:Contribution/bf:agent/bf:Agent/bflc:name00MarcKey = '1001 $aBeethoven, Ludwig van,$d1770-1827$c(Spirit)$0(DE-101c)310008891$2naf'"/>
     <x:expect label="bf:Agent/rdfs:label generation" test="//bf:Work[1]/bf:contribution[1]/bf:Contribution/bf:agent/bf:Agent/rdfs:label = 'Beethoven, Ludwig van, 1770-1827 (Spirit)'"/>
     <x:expect label="$0 becomes a bf:identifiedBy property for the bf:Agent" test="//bf:Agent[@rdf:about='http://example.org/1#Agent100-2']/bf:identifiedBy/bf:Identifier/rdf:value = '310008891'"/>
-    <x:expect label="$2 becomes a bf:source property for the bf:Agent" test="//bf:Work[1]/bf:contribution[1]/bf:Contribution/bf:agent/bf:Agent/bf:source/bf:Source/rdfs:label = 'naf'"/>
+    <x:expect label="$2 becomes a bf:source property for the bf:Agent" test="//bf:Work[1]/bf:contribution[1]/bf:Contribution/bf:agent/bf:Agent/bf:source/bf:Source/bf:code = 'naf'"/>
     <x:expect label="...unless there is a $t, in which case it's the bf:identifiedBy for the bf:Work" test="//bf:Work[@rdf:about='http://example.org/1#Work700-6']/bf:identifiedBy/bf:Identifier/rdf:value = '0000000121358464'"/>
     <x:expect label="...or if it is a URI, it becomes the rdf:about attribute of the bf:Agent or bf:Work" test="//bf:Work[1]/bf:contribution[3]/bf:Contribution/bf:agent/bf:Agent/@rdf:about = 'http://id.loc.gov/authorities/names/n81042545'"/>
   </x:scenario>

--- a/test/ConvSpec-240andX30-UnifTitle.xspec
+++ b/test/ConvSpec-240andX30-UnifTitle.xspec
@@ -46,7 +46,7 @@
     <x:expect label="$r becomes a musicKey" test="//bf:Work[@rdf:about='http://example.org/1#Work']/bf:musicKey = 'D major'"/>
     <x:expect label="$s becomes a version" test="//bf:Work[@rdf:about='http://example.org/2#Work730-4']/bf:version = 'Codex Sinaiticus'"/>
     <x:expect label="$x becomes an Issn" test="//bf:Work[@rdf:about='http://example.org/2#Work730-5']/bf:identifiedBy/bf:Issn = '1234-5678'"/>
-    <x:expect label="$2 becomes a source" test="//bf:Work[@rdf:about='http://example.org/1#Work']/bf:subject[1]/bf:Topic/madsrdf:componentList/bf:Work/bf:source/bf:Source/rdfs:label='example'"/>
+    <x:expect label="$2 becomes a source" test="//bf:Work[@rdf:about='http://example.org/1#Work']/bf:subject[1]/bf:Topic/madsrdf:componentList/bf:Work/bf:source/bf:Source/bf:code='example'"/>
     <x:expect label="$0 becomes an identifiedBy" test="//bf:Work[@rdf:about='http://example.org/1#Work']/bf:identifiedBy[1]/bf:Identifier/rdf:value = '0001'"/>
     <x:expect label="$0/$w, if a URI, becomes the rdf:about attribute of the bf:Work for 630, 730, 830" test="//bf:Work[@rdf:about='http://example.org/1#Work']/bf:subject[1]/bf:Topic/madsrdf:componentList/bf:Work/@rdf:about = 'http://example.org/9999#Work'"/>
     <x:expect label="$3 becomes a bflc:appliesTo" test="//bf:Work[@rdf:about='http://example.org/2#Work730-4']/bflc:appliesTo/bflc:AppliesTo/rdfs:label = '1980'"/>

--- a/test/ConvSpec-250-270.xspec
+++ b/test/ConvSpec-250-270.xspec
@@ -42,7 +42,7 @@
   <x:scenario label="257 - COUNTRY OF PRODUCING ENTITY">
     <x:context href="data/ConvSpec-250-270/marc.xml"/>
     <x:expect label="257 creates an originPlace/Place property of the Work" test="//bf:Work[1]/bf:originPlace/bf:Place/rdfs:label = 'France'"/>
-    <x:expect label="$2 creates a source property of the Place" test="//bf:Work[1]/bf:originPlace/bf:Place/bf:source/bf:Source/rdfs:label = 'naf'"/>
+    <x:expect label="$2 creates a source property of the Place" test="//bf:Work[1]/bf:originPlace/bf:Place/bf:source/bf:Source/bf:code = 'naf'"/>
   </x:scenario>
 
   <x:scenario label="260 - PUBLICATION, DISTRIBUTION, ETC. (IMPRINT)">

--- a/test/ConvSpec-3XX.xspec
+++ b/test/ConvSpec-3XX.xspec
@@ -84,7 +84,7 @@
     <x:expect label="$o creates a polarity property of the Instance" test="//bf:Instance[1]/bf:polarity[1]/bf:Polarity/rdfs:label = 'positive'"/>
     <x:expect label="$0 creates an identifiedBy property of the generated object" test="//bf:Work[1]/bf:colorContent[1]/bf:ColorContent/bf:identifiedBy/bf:Identifier/rdf:value = '123456'"/>
     <x:expect label="...or sets the URI of the generated object" test="//bf:Instance[1]/bf:fontSize[1]/bf:FontSize/@rdf:about = 'http://rdaregistry.info/termList/fontSize/1001'"/>
-    <x:expect label="$2 creates a source property on generated Resources" test="//bf:Instance[1]/bf:generation[1]/bf:Generation/bf:source/bf:Source/rdfs:label = 'rda'"/>
+    <x:expect label="$2 creates a source property on generated Resources" test="//bf:Instance[1]/bf:generation[1]/bf:Generation/bf:source/bf:Source/bf:code = 'rda'"/>
   </x:scenario>
 
   <x:scenario label="341 - ACCESSIBILITY CONTENT">
@@ -95,7 +95,7 @@
     <x:expect label="$c creates an rdfs:label with prefix 'Visual assistive features:'" test="//bf:Work[1]/bf:contentAccessibility[2]/bf:ContentAccessibility/rdfs:label[2] = 'Visual assistive features: signLanguage'"/>
     <x:expect label="$d creates an rdfs:label with prefix 'Auditory assistive features:'" test="//bf:Work[1]/bf:contentAccessibility[3]/bf:ContentAccessibility/rdfs:label[2] = 'Auditory assistive features: audioDescription'"/>
     <x:expect label="$e creates an rdfs:label with prefix 'Tactile assistive features:'" test="//bf:Work[1]/bf:contentAccessibility[4]/bf:ContentAccessibility/rdfs:label[2] = 'Tactile assistive features: braille'"/>
-    <x:expect label="$2 creates a source property on the ContentAccessibility subject" test="//bf:Work[1]/bf:contentAccessibility[1]/bf:ContentAccessibility/bf:source/bf:Source/rdfs:label = 'termList'"/>
+    <x:expect label="$2 creates a source property on the ContentAccessibility subject" test="//bf:Work[1]/bf:contentAccessibility[1]/bf:ContentAccessibility/bf:source/bf:Source/bf:code = 'termList'"/>
     <x:expect label="$3 creates a bflc:appliesTo property on ContentAccessibility subject" test="//bf:Work[1]/bf:contentAccessibility[1]/bf:ContentAccessibility/bflc:appliesTo/bflc:AppliesTo/rdfs:label = 'accompanying audio CD'"/>
   </x:scenario>
 
@@ -115,7 +115,7 @@
     <x:expect label="$h creates a soundCharacteristic/PlaybackCharacteristic property of the Instance" test="//bf:Instance[1]/bf:soundCharacteristic[4]/bf:PlaybackCharacteristic/rdfs:label = 'Dolby'"/>
     <x:expect label="...with an rdf:about attribute if recognized value (see specs for details)" test="//bf:Instance[1]/bf:soundCharacteristic[4]/bf:PlaybackCharacteristic/@rdf:about = 'http://id.loc.gov/vocabulary/mspecplayback/dolby'"/>
     <x:expect label="$0 creates an identifiedBy property of the generated object" test="//bf:Instance[1]/bf:soundCharacteristic[4]/bf:PlaybackCharacteristic/bf:identifiedBy/bf:Identifier/rdf:value/@rdf:resource = 'http://id.loc.gov/vocabulary/mspecplayback/dolby'"/>
-    <x:expect label="$2 creates a source property on generated Resources" test="//bf:Instance[1]/bf:soundCharacteristic[1]/bf:RecordingMethod/bf:source/bf:Source/rdfs:label = 'rda'"/>
+    <x:expect label="$2 creates a source property on generated Resources" test="//bf:Instance[1]/bf:soundCharacteristic[1]/bf:RecordingMethod/bf:source/bf:Source/bf:code = 'rda'"/>
     <x:expect label="$3 creates a bflc:appliesTo property on generated Resources" test="//bf:Instance[1]/bf:soundCharacteristic[1]/bf:RecordingMethod/bflc:appliesTo/bflc:AppliesTo/rdfs:label = 'audio disc'"/>
   </x:scenario>
   
@@ -125,7 +125,7 @@
     <x:expect label="...with an rdf:about attribute if matches string in spec" test="//bf:Instance[1]/bf:projectionCharacteristic[1]/bf:PresentationFormat/@rdf:about = 'http://id.loc.gov/vocabulary/mpresformat/ciner'"/>
     <x:expect label="$b creates a projectionCharacteristic/ProjectionSpeed property of the Instance" test="//bf:Instance[1]/bf:projectionCharacteristic[2]/bf:ProjectionSpeed/rdfs:label = '24 fps'"/>
     <x:expect label="$0 creates an identifiedBy property of the generated object" test="//bf:Instance[1]/bf:projectionCharacteristic[1]/bf:PresentationFormat/bf:identifiedBy/bf:Identifier/rdf:value/@rdf:resource = 'http://id.loc.gov/vocabulary/mpresformat/ciner'"/>
-    <x:expect label="$2 creates a source property on generated Resources" test="//bf:Instance[1]/bf:projectionCharacteristic[1]/bf:PresentationFormat/bf:source/bf:Source/rdfs:label = 'rda'"/>
+    <x:expect label="$2 creates a source property on generated Resources" test="//bf:Instance[1]/bf:projectionCharacteristic[1]/bf:PresentationFormat/bf:source/bf:Source/bf:code = 'rda'"/>
     <x:expect label="$3 creates a bflc:appliesTo property on generated Resources" test="//bf:Instance[1]/bf:projectionCharacteristic[1]/bf:PresentationFormat/bflc:appliesTo/bflc:AppliesTo/rdfs:label = 'filmstrip'"/>
   </x:scenario>
     
@@ -136,7 +136,7 @@
     <x:expect label="$b creates a videoCharacteristic/BroadcastStandard property of the Instance" test="//bf:Instance[1]/bf:videoCharacteristic[2]/bf:BroadcastStandard/rdfs:label = 'PAL'"/>
     <x:expect label="...with an rdf:about attribute if matches string in spec" test="//bf:Instance[1]/bf:videoCharacteristic[2]/bf:BroadcastStandard/@rdf:about = 'http://id.loc.gov/vocabulary/mbroadstd/pal'"/>
     <x:expect label="$0 creates an identifiedBy property of the generated object" test="//bf:Instance[1]/bf:videoCharacteristic[2]/bf:BroadcastStandard/bf:identifiedBy/bf:Identifier/rdf:value/@rdf:resource = 'http://id.loc.gov/vocabulary/mbroadstd/pal'"/>
-    <x:expect label="$2 creates a source property on generated Resources" test="//bf:Instance[1]/bf:videoCharacteristic[1]/bf:VideoFormat/bf:source/bf:Source/rdfs:label = 'rda'"/>
+    <x:expect label="$2 creates a source property on generated Resources" test="//bf:Instance[1]/bf:videoCharacteristic[1]/bf:VideoFormat/bf:source/bf:Source/bf:code = 'rda'"/>
     <x:expect label="$3 creates a bflc:appliesTo property on generated Resources" test="//bf:Instance[1]/bf:videoCharacteristic[1]/bf:VideoFormat/bflc:appliesTo/bflc:AppliesTo/rdfs:label = 'videotape'"/>
   </x:scenario>
 
@@ -152,7 +152,7 @@
     <x:expect label="...with an rdf:about attribute if matches string in spec" test="//bf:Instance[1]/bf:digitalCharacteristic[5]/bf:RegionalEncoding/@rdf:about = 'http://id.loc.gov/vocabulary/mregencoding/region4'"/>
     <x:expect label="$f creates a digitalCharacteristic/EncodedBitrate property of the Instance" test="//bf:Instance[1]/bf:digitalCharacteristic[6]/bf:EncodedBitrate/rdfs:label = '32 kbps'"/>
     <x:expect label="$0 creates an identifiedBy property of the generated object" test="//bf:Instance[1]/bf:digitalCharacteristic[2]/bf:EncodingFormat/bf:identifiedBy/bf:Identifier/rdf:value/@rdf:resource = 'http://id.loc.gov/vocabulary/mvidformat/bluray'"/>
-    <x:expect label="$2 creates a source property on generated Resources" test="//bf:Instance[1]/bf:digitalCharacteristic[1]/bf:FileType/bf:source/bf:Source/rdfs:label = 'rda'"/>
+    <x:expect label="$2 creates a source property on generated Resources" test="//bf:Instance[1]/bf:digitalCharacteristic[1]/bf:FileType/bf:source/bf:Source/bf:code = 'rda'"/>
     <x:expect label="$3 creates a bflc:appliesTo property on generated Resources" test="//bf:Instance[1]/bf:digitalCharacteristic[1]/bf:FileType/bflc:appliesTo/bflc:AppliesTo/rdfs:label = 'computer disc'"/>
   </x:scenario>
 
@@ -162,7 +162,7 @@
     <x:expect label="$a creates an rdfs:label property of the MusicFormat" test="//bf:Instance[1]/bf:musicFormat[1]/bf:MusicFormat/rdfs:label = 'vocal score'"/>
     <x:expect label="...with an rdf:about attribute if matches string in spec" test="//bf:Instance[1]/bf:musicFormat[1]/bf:MusicFormat/@rdf:about = 'http://id.loc.gov/vocabulary/mmusicformat/vocalscore'"/>
     <x:expect label="$0 creates an identifiedBy property of the MusicFormat" test="//bf:Instance[1]/bf:musicFormat[1]/bf:MusicFormat/bf:identifiedBy/bf:Identifier/rdf:value = '12345'"/>
-    <x:expect label="$2 creates a source property of the MusicFormat" test="//bf:Instance[1]/bf:musicFormat[1]/bf:MusicFormat/bf:source/bf:Source/rdfs:label = 'foo'"/>
+    <x:expect label="$2 creates a source property of the MusicFormat" test="//bf:Instance[1]/bf:musicFormat[1]/bf:MusicFormat/bf:source/bf:Source/bf:code = 'foo'"/>
     <x:expect label="$3 creates a bflc:appliesTo property of the MusicFormat" test="//bf:Instance[1]/bf:musicFormat[1]/bf:MusicFormat/bflc:appliesTo/bflc:AppliesTo/rdfs:label = 'enclosed score'"/>
   </x:scenario>
 
@@ -240,7 +240,7 @@
     <x:expect label="$s creates a musicMedium/MusicMedium property of the Work with a note property" test="//bf:Work[1]/bf:musicMedium[4]/bf:MusicMedium/bf:note/bf:Note/rdfs:label = 'Total performers: 2'"/>
     <x:expect label="$t creates a musicMedium/MusicMedium property of the Work with a note property" test="//bf:Work[1]/bf:musicMedium[9]/bf:MusicMedium/bf:note/bf:Note/rdfs:label = 'Total ensembles: 1'"/>
     <x:expect label="$v after $r/$s/$t creates a musicMedium/MusicMedium property of the Work with a note property" test="//bf:Work[1]/bf:musicMedium[5]/bf:MusicMedium/bf:note/bf:Note/rdfs:label = 'piano is prominent, but not all other instruments are not identified'"/>
-    <x:expect label="$2 creates a source property of the MusicMedium" test="//bf:Work[1]/bf:musicMedium[1]/bf:MusicMedium/bf:source/bf:Source/rdfs:label = 'lcmpt'"/>
+    <x:expect label="$2 creates a source property of the MusicMedium" test="//bf:Work[1]/bf:musicMedium[1]/bf:MusicMedium/bf:source/bf:Source/bf:code = 'lcmpt'"/>
     <x:expect label="$3 creates a bflc:appliesTo property of the MusicMedium" test="//bf:Work[1]/bf:musicMedium[1]/bf:MusicMedium/bflc:appliesTo/bflc:AppliesTo/rdfs:label = 'Nach Bach'"/>
   </x:scenario>
 
@@ -264,7 +264,7 @@
     <x:expect label="If there is a $0 with a standard number value starting with 'dg', it becomes the URI of the IntendedAudience" test="//bf:Work[1]/bf:intendedAudience[2]/bf:IntendedAudience/@rdf:about = 'http://id.loc.gov/authorities/demographicTerms/dg2015060010'"/>
     <x:expect label="$m creates a bflc:demographicGroup property of the IntendedAudience" test="//bf:Work[1]/bf:intendedAudience[1]/bf:IntendedAudience/bflc:demographicGroup/bflc:DemographicGroup/rdfs:label = 'Age group'"/>
     <x:expect label="$n sets the URI of the DemographicGroup" test="//bf:Work[1]/bf:intendedAudience[1]/bf:IntendedAudience/bflc:demographicGroup/bflc:DemographicGroup/@rdf:about = 'http://id.loc.gov/authorities/demographicTerms/age'"/>
-    <x:expect label="$2 creates a source property of the IntendedAudience" test="//bf:Work[1]/bf:intendedAudience[1]/bf:IntendedAudience/bf:source/bf:Source/rdfs:label = 'ws'"/>
+    <x:expect label="$2 creates a source property of the IntendedAudience" test="//bf:Work[1]/bf:intendedAudience[1]/bf:IntendedAudience/bf:source/bf:Source/bf:code = 'ws'"/>
     <x:expect label="$3 creates a bflc:appliesTo property of the IntendedAudience" test="//bf:Work[1]/bf:intendedAudience[1]/bf:IntendedAudience/bflc:appliesTo/bflc:AppliesTo/rdfs:label = 'Nonsense'"/>
   </x:scenario>
   
@@ -275,7 +275,7 @@
     <x:expect label="If there is a $0 with a standard number value starting with 'dg', it becomes the URI of the CreatorCharacteristic" test="//bf:Work[1]/bflc:creatorCharacteristic[2]/bflc:CreatorCharacteristic/@rdf:about = 'http://id.loc.gov/authorities/demographicTerms/dg2015060010'"/>
     <x:expect label="$m creates a bflc:demographicGroup property of the CreatorCharacteristic" test="//bf:Work[1]/bflc:creatorCharacteristic[1]/bflc:CreatorCharacteristic/bflc:demographicGroup/bflc:DemographicGroup/rdfs:label = 'Gender group'"/>
     <x:expect label="$n sets the URI of the DemographicGroup" test="//bf:Work[1]/bflc:creatorCharacteristic[1]/bflc:CreatorCharacteristic/bflc:demographicGroup/bflc:DemographicGroup/@rdf:about = 'http://id.loc.gov/authorities/demographicTerms/gen'"/>
-    <x:expect label="$2 creates a source property of the CreatorCharacteristic" test="//bf:Work[1]/bflc:creatorCharacteristic[1]/bflc:CreatorCharacteristic/bf:source/bf:Source/rdfs:label = 'ericd'"/>
+    <x:expect label="$2 creates a source property of the CreatorCharacteristic" test="//bf:Work[1]/bflc:creatorCharacteristic[1]/bflc:CreatorCharacteristic/bf:source/bf:Source/bf:code = 'ericd'"/>
     <x:expect label="$3 creates a bflc:appliesTo property of the CreatorCharacteristic" test="//bf:Work[1]/bflc:creatorCharacteristic[1]/bflc:CreatorCharacteristic/bflc:appliesTo/bflc:AppliesTo/rdfs:label = 'Other stuff'"/>
   </x:scenario>
   

--- a/test/ConvSpec-5XX.xspec
+++ b/test/ConvSpec-5XX.xspec
@@ -159,7 +159,7 @@
     <x:expect label="$acfgq creates an rdfs:label property of the UsePolicy" test="//bf:Instance[1]/bf:usageAndAccessPolicy[2]/bf:UsePolicy/rdfs:label[1] = 'Photocopying prohibited; 50 Stat.88; CC BY-NC-ND 20190523 DLC'"/>
     <x:expect label="$d creates a note property of the UsePolicy" test="//bf:Instance[1]/bf:usageAndAccessPolicy[2]/bf:UsePolicy/bf:note/bf:Note/rdfs:label = 'Authorized users: Executor of estate'"/>
     <x:expect label="$u creates an rdfs:label property of the UsePolicy" test="//bf:Instance[1]/bf:usageAndAccessPolicy[2]/bf:UsePolicy/rdfs:label[2] = 'http://lcweb.loc.gov/rr/print/195_copr.html'"/>
-    <x:expect label="$2 creates a bf:source property of the UserPolicy" test="//bf:Instance[1]/bf:usageAndAccessPolicy[2]/bf:UsePolicy/bf:source/bf:Source/rdfs:label = 'HCO'"/>
+    <x:expect label="$2 creates a bf:source property of the UserPolicy" test="//bf:Instance[1]/bf:usageAndAccessPolicy[2]/bf:UsePolicy/bf:source/bf:Source/bf:code = 'HCO'"/>
     <x:expect label="$3 creates a bflc:appliesTo property of the UsePolicy" test="//bf:Instance[1]/bf:usageAndAccessPolicy[2]/bf:UsePolicy/bflc:appliesTo/bflc:AppliesTo/rdfs:label = 'Diaries'"/>
     <x:expect label="$5 creates a bflc:applicableInstitution property of the UsePolicy" test="//bf:Instance[1]/bf:usageAndAccessPolicy[2]/bf:UsePolicy/bflc:applicableInstitution/bf:Agent/bf:code = 'DLC'"/>
   </x:scenario>
@@ -251,7 +251,7 @@
     <x:expect label="$l creates a status property of the Note" test="//bf:Instance[1]/bf:hasItem[2]/bf:Item/bf:note[2]/bf:Note/bf:status/bf:Status/rdfs:label = 'mutilated'"/>
     <x:expect label="$u creates an rdfs:label property of the Note" test="//bf:Instance[1]/bf:hasItem[2]/bf:Item/bf:note[2]/bf:Note/rdfs:label[3] = 'http://karamelik.eastlib.ufl.edu/cgi-bin/conserve/rara.pl'"/>
     <x:expect label="$z creates a note/Note property of the Note" test="//bf:Instance[1]/bf:hasItem[2]/bf:Item/bf:note[2]/bf:Note/bf:note/bf:Note/rdfs:label = 'Institute for Museum and Library Services grant'"/>
-    <x:expect label="$2 creates a source property of the Note" test="//bf:Instance[1]/bf:hasItem[2]/bf:Item/bf:note[2]/bf:Note/bf:source/bf:Source/rdfs:label = 'pda'"/>
+    <x:expect label="$2 creates a source property of the Note" test="//bf:Instance[1]/bf:hasItem[2]/bf:Item/bf:note[2]/bf:Note/bf:source/bf:Source/bf:code = 'pda'"/>
   </x:scenario>
 
   <x:scenario label="585 - EXHIBITIONS NOTE">

--- a/test/ConvSpec-648-662.xspec
+++ b/test/ConvSpec-648-662.xspec
@@ -55,7 +55,7 @@
     <x:expect label="...with rdf:type of madsrdf:ComplexSubject" test="//bf:Work[1]/bf:subject[7]/bf:Topic/rdf:type/@rdf:resource = 'http://www.loc.gov/mads/rdf/v1#ComplexSubject'"/>
     <x:expect label="$akvxyz creates an rdfs:label property of the Topic" test="//bf:Work[1]/bf:subject[7]/bf:Topic/rdfs:label = 'Chauffeurs--France.'"/>
     <x:expect label="...and become components in the madsrdf:componentList of the Topic" test="//bf:Work[1]/bf:subject[7]/bf:Topic/madsrdf:componentList/madsrdf:Occupation/rdfs:label = 'Chauffeurs'"/>
-    <x:expect label="$2 creates a source property of the Topic" test="//bf:Work[1]/bf:subject[7]/bf:Topic/bf:source/bf:Source/rdfs:label = 'someCode'"/>
+    <x:expect label="$2 creates a source property of the Topic" test="//bf:Work[1]/bf:subject[7]/bf:Topic/bf:source/bf:Source/bf:code = 'someCode'"/>
   </x:scenario>
   
   <x:scenario label="662 - SUBJECT ADDED ENTRY--HIERARCHICAL PLACE NAME">

--- a/test/ConvSpec-720+740to755.xspec
+++ b/test/ConvSpec-720+740to755.xspec
@@ -37,7 +37,7 @@
     <x:expect label="$c creates a systemRequirement/bflc:OperatingSystem property of the Instance" test="//bf:Instance[1]/bf:systemRequirement[3]/bflc:OperatingSystem/rdfs:label = 'DOS 1.1'"/>
     <x:expect label="First $0 with a URI after a subfield sets the URI of the object" test="//bf:Instance[1]/bf:systemRequirement[3]/bflc:OperatingSystem/@rdf:about = 'http://example.org/platform/obsolete'"/>
     <x:expect label="Additional $0s create bf:identifiedBy properties of the object" test="//bf:Instance[1]/bf:systemRequirement[3]/bflc:OperatingSystem/bf:identifiedBy/bf:Identifier/rdf:value/@rdf:resource = 'http://example.com/platform/obsolete'"/>
-    <x:expect label="$2 creates a source property of the object" test="//bf:Instance[1]/bf:systemRequirement[2]/bflc:ProgrammingLanguage/bf:source/bf:Source/rdfs:label = 'exampleplatform'"/>
+    <x:expect label="$2 creates a source property of the object" test="//bf:Instance[1]/bf:systemRequirement[2]/bflc:ProgrammingLanguage/bf:source/bf:Source/bf:code = 'exampleplatform'"/>
   </x:scenario>
   
 </x:description>

--- a/test/ConvSpec-760-788-Links.xspec
+++ b/test/ConvSpec-760-788-Links.xspec
@@ -50,7 +50,7 @@
     <x:expect label="$u creates an identifiedBy/Strn property of the linked Instance" test="/rdf:RDF/bf:Work[1]/bf:absorbed[1]/bf:Work/bf:hasInstance/bf:Instance/bf:identifiedBy/bf:Strn/rdf:value = 'MPC-387'"/>
     <x:expect label="$v creates a note property of the linked Work" test="/rdf:RDF/bf:Work[1]/bf:dataSource[1]/bf:Work/bf:note/bf:Note/rdfs:label = 'Data for reformatting to DEM format'"/>
     <x:expect label="$w creates an identifiedBy/Identifier property of the linked Instance" test="/rdf:RDF/bf:Work[1]/bf:translationOf[1]/bf:Work/bf:hasInstance/bf:Instance/bf:identifiedBy[2]/bf:Identifier/rdf:value = '4798581'"/>
-    <x:expect label="...with source from parenthetical qualifier" test="//bf:Work[1]/bf:translationOf[1]/bf:Work/bf:hasInstance/bf:Instance/bf:identifiedBy[2]/bf:Identifier/bf:source/bf:Source/rdfs:label = 'OCoLC'"/>
+    <x:expect label="...with source from parenthetical qualifier" test="//bf:Work[1]/bf:translationOf[1]/bf:Work/bf:hasInstance/bf:Instance/bf:identifiedBy[2]/bf:Identifier/bf:source/bf:Source/bf:code = 'OCoLC'"/>
     <x:expect label="...unless qualifier is DLC, when it creates an Lccn" test="/rdf:RDF/bf:Work[1]/bf:translationOf[1]/bf:Work/bf:hasInstance/bf:Instance/bf:identifiedBy[1]/bf:Lccn/rdf:value = '   78648457 '"/>
     <x:expect label="$x creates an identifiedBy/Issn property of the linked Instance" test="/rdf:RDF/bf:Work[1]/bf:translation[1]/bf:Work/bf:hasInstance/bf:Instance/bf:identifiedBy/bf:Issn/rdf:value = '0190-2709'"/>
     <x:expect label="$y creates an identifiedBy/Coden property of the linked Instance" test="/rdf:RDF/bf:Work[1]/bf:partOf[1]/bf:Work/bf:hasInstance/bf:Instance/bf:identifiedBy/bf:Coden/rdf:value = 'FNMMA'"/>

--- a/test/marc2bibframe2.xspec
+++ b/test/marc2bibframe2.xspec
@@ -590,7 +590,7 @@
                 <bf:classificationPortion>975.3</bf:classificationPortion>
                 <bf:source>
                   <bf:Source>
-                    <rdfs:label>13</rdfs:label>
+                    <bf:code>13</bf:code>
                   </bf:Source>
                 </bf:source>
                 <bf:edition>abridged</bf:edition>
@@ -904,7 +904,7 @@
                 <bf:classificationPortion>658.4</bf:classificationPortion>
                 <bf:source>
                   <bf:Source>
-                    <rdfs:label>20</rdfs:label>
+                    <bf:code>20</bf:code>
                   </bf:Source>
                 </bf:source>
                 <bf:edition>full</bf:edition>

--- a/xsl/ConvSpec-010-048.xsl
+++ b/xsl/ConvSpec-010-048.xsl
@@ -666,7 +666,7 @@
                     <xsl:when test="@code='c'">
                       <bf:source>
                         <bf:Source>
-                          <rdfs:label>ISO 3166</rdfs:label>
+                          <bf:code>ISO 3166</bf:code>
                         </bf:Source>
                       </bf:source>
                     </xsl:when>
@@ -1306,9 +1306,13 @@
                 </bf:StockNumber>
               </bf:identifiedBy>
             </xsl:for-each>
-            <xsl:apply-templates select="marc:subfield[@code='b']" mode="subfield2">
-              <xsl:with-param name="serialization" select="$serialization"/>
-            </xsl:apply-templates>
+            <xsl:for-each select="marc:subfield[@code='b']">
+              <bf:source>
+                <bf:Source>
+                  <rdfs:label><xsl:value-of select="."/></rdfs:label>
+                </bf:Source>
+              </bf:source>
+            </xsl:for-each>
             <xsl:for-each select="marc:subfield[@code='c']">
               <bf:acquisitionTerms><xsl:value-of select="."/></bf:acquisitionTerms>
             </xsl:for-each>

--- a/xsl/ConvSpec-ControlSubfields.xsl
+++ b/xsl/ConvSpec-ControlSubfields.xsl
@@ -91,7 +91,7 @@
             <xsl:if test="$source != '' and $source != 'uri'">
               <bf:source>
                 <bf:Source>
-                  <rdfs:label><xsl:value-of select="$source"/></rdfs:label>
+                  <bf:code><xsl:value-of select="$source"/></bf:code>
                 </bf:Source>
               </bf:source>
             </xsl:if>
@@ -104,17 +104,23 @@
   <!-- create a bf:source property from a subfield $2 -->
   <xsl:template match="marc:subfield" mode="subfield2">
     <xsl:param name="serialization" select="'rdfxml'"/>
-    <xsl:variable name="vXmlLang"><xsl:apply-templates select="parent::*" mode="xmllang"/></xsl:variable>
+    <xsl:param name="pVocabStem"/>
     <xsl:choose>
       <xsl:when test="$serialization='rdfxml'">
         <bf:source>
           <bf:Source>
-            <rdfs:label>
-              <xsl:if test="$vXmlLang != ''">
-                <xsl:attribute name="xml:lang"><xsl:value-of select="$vXmlLang"/></xsl:attribute>
-              </xsl:if>
+            <xsl:if test="$pVocabStem != ''">
+              <xsl:variable name="vNormCode">
+                <xsl:call-template name="url-encode">
+                  <xsl:with-param name="str" select="normalize-space(translate(.,$upper,$lower))"/>
+                </xsl:call-template>
+              </xsl:variable>
+              <xsl:attribute name="rdf:about"><xsl:value-of
+              select="concat($pVocabStem,.)"/></xsl:attribute>
+            </xsl:if>
+            <bf:code>
               <xsl:value-of select="."/>
-            </rdfs:label>
+            </bf:code>
           </bf:Source>
         </bf:source>
       </xsl:when>


### PR DESCRIPTION
* Use bf:code instead of rdfs:label for generic case

Towards ConvSpec-NumericSubfields-v1.6