### PR TITLE
Update uniform title conversion for $m and $r.

### DIFF
--- a/test/ConvSpec-010-048.xspec
+++ b/test/ConvSpec-010-048.xspec
@@ -182,7 +182,7 @@
     <x:expect label="038 creates a bflc:metadataLicensor property of the Work AdminMetadata" test="//bf:Work/bf:adminMetadata/bf:AdminMetadata/bflc:metadataLicensor/bflc:MetadataLicensor/rdfs:label = 'Uk'"/>
   </x:scenario>
 
-  <x:scenario label="040 - CATALOGING SOURCE" focus="040">
+  <x:scenario label="040 - CATALOGING SOURCE">
     <x:context href="data/ConvSpec-010-048/marc.xml"/>
     <x:expect label="040 creates an assigner property of the Work AdminMetadata" test="//bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:assigner[1]/bf:Agent/bf:code = 'NBPol-G'"/>
     <x:expect label="...and a uri if $a = DLC" test="//bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:assigner[2]/bf:Agent/@rdf:about='http://id.loc.gov/vocabulary/organizations/dlc'"/>

--- a/test/ConvSpec-240andX30-UnifTitle.xspec
+++ b/test/ConvSpec-240andX30-UnifTitle.xspec
@@ -30,7 +30,7 @@
     <x:expect label="630/730/830 creates new Work entity" test="count(//bf:Work[@rdf:about='http://example.org/2#Work730-4']) = 1"/>
     <x:expect label="730 I2=2 with no $i becomes a hasPart of the main Work" test="//bf:Work[@rdf:about='http://example.org/2#Work']/bf:hasPart/bf:Work/bf:title/bf:Title/bf:mainTitle = 'Bible'"/>
     <x:expect label="730 otherwise becomes a relatedTo of the main Work" test="//bf:Work[@rdf:about='http://example.org/2#Work']/bf:relatedTo/bf:Work/bf:title/bf:Title/bf:mainTitle = '[Motets]'"/>
-    <x:expect label="$i becomes a bflc:relationship of the main Work" test="//bf:Work[@rdf:about='http://example.org/2#Work']/bflc:relationship/bflc:Relationship/bflc:relation/bflc:Relation/rdfs:label='Parody of (work)' and //bf:Work[@rdf:about='http://example.org/2#Work']/bflc:relationship/bflc:Relationship/bf:relatedTo/@rdf:resource='http://example.org/2#Work730-5'"/>
+    <x:expect label="$i becomes a bflc:relationship of the main Work" test="//bf:Work[@rdf:about='http://example.org/2#Work']/bflc:relationship/bflc:Relationship/bflc:relation/bflc:Relation/rdfs:label='Parody of (work)' and //bf:Work[@rdf:about='http://example.org/2#Work']/bflc:relationship/bflc:Relationship/bf:relatedTo/@rdf:resource='http://example.org/2#Work730-6'"/>
     <x:expect label="$d becomes a legalDate" test="//bf:Work[@rdf:about='http://example.org/1#Work']/bf:legalDate = '1952'"/>
     <x:expect label="$f becomes the originDate" test="//bf:Work[@rdf:about='http://example.org/1#Work']/bf:originDate = '[between 1775 and 1800]'"/>
     <x:expect label="$l creates a translationOf property" test="count(//bf:Work[@rdf:about='http://example.org/4#Work']/bf:translationOf) = 1"/>
@@ -43,13 +43,14 @@
     <x:expect label="...with rdfs:label that does not include $o" test="//bf:Work[@rdf:about='http://example.org/1#Work']/bflc:arrangementOf/bf:Work/rdfs:label = 'The Encyclopedia of Latin American history and culture. (1952). [between 1775 and 1800]. Manuscripts, Latin. Sound recording. violin, viola, D major. O.T. Book 4. Selections.'"/>
     <x:expect label="...for 240, add contribution from 1XX to stub Work" test="//bf:Work[@rdf:about='http://example.org/6#Work']/bflc:arrangementOf/bf:Work/bf:contribution/bf:Contribution/bf:agent/bf:Agent/rdfs:label = 'Nefwich, Harvey.'"/>
     <x:expect label="$r becomes a musicKey (if no 384)" test="//bf:Work[@rdf:about='http://example.org/1#Work']/bf:musicKey = 'D major'"/>
+    <x:expect label="$r always becomes a musicKey if uniform title is not a main entry" test="//bf:Work[@rdf:about='http://example.org/2#Work']/bf:relatedTo/bf:Work/bf:musicKey = 'E minor'"/>
     <x:expect label="$s becomes a version" test="//bf:Work[@rdf:about='http://example.org/2#Work730-4']/bf:version = 'Codex Sinaiticus'"/>
-    <x:expect label="$x becomes an Issn" test="//bf:Work[@rdf:about='http://example.org/2#Work730-5']/bf:identifiedBy/bf:Issn = '1234-5678'"/>
+    <x:expect label="$x becomes an Issn" test="//bf:Work[@rdf:about='http://example.org/2#Work730-6']/bf:identifiedBy/bf:Issn = '1234-5678'"/>
     <x:expect label="$2 becomes a source" test="//bf:Work[@rdf:about='http://example.org/1#Work']/bf:subject[1]/bf:Topic/madsrdf:componentList/bf:Work/bf:source/bf:Source/bf:code='example'"/>
     <x:expect label="$0 becomes an identifiedBy" test="//bf:Work[@rdf:about='http://example.org/1#Work']/bf:identifiedBy[1]/bf:Identifier/rdf:value = '0001'"/>
     <x:expect label="$0/$w, if a URI, becomes the rdf:about attribute of the bf:Work for 630, 730, 830" test="//bf:Work[@rdf:about='http://example.org/1#Work']/bf:subject[1]/bf:Topic/madsrdf:componentList/bf:Work/@rdf:about = 'http://example.org/9999#Work'"/>
     <x:expect label="$3 becomes a bflc:appliesTo" test="//bf:Work[@rdf:about='http://example.org/2#Work730-4']/bflc:appliesTo/bflc:AppliesTo/rdfs:label = '1980'"/>
-    <x:expect label="$5 becomes a bflc:applicableInstitution" test="//bf:Work[@rdf:about='http://example.org/2#Work730-5']/bflc:applicableInstitution/bf:Agent/bf:code = 'DLC'"/>
+    <x:expect label="$5 becomes a bflc:applicableInstitution" test="//bf:Work[@rdf:about='http://example.org/2#Work730-6']/bflc:applicableInstitution/bf:Agent/bf:code = 'DLC'"/>
   </x:scenario>
 
 </x:description>

--- a/test/data/ConvSpec-240andX30-UnifTitle/marc.xml
+++ b/test/data/ConvSpec-240andX30-UnifTitle/marc.xml
@@ -50,9 +50,13 @@
       <subfield code="p">Psalms.</subfield>
       <subfield code="s">Codex Sinaiticus.</subfield>
     </datafield>
+    <datafield tag="384" ind1=" " ind2=" ">
+      <subfield code="a">B-flat minor</subfield>
+    </datafield>
     <datafield tag="730" ind1="0" ind2="2">
       <subfield code="i">Parody of (work):</subfield>
       <subfield code="a">[Motets].</subfield>
+      <subfield code="r">E minor</subfield>
       <subfield code="h">Sound recording</subfield>
       <subfield code="x">1234-5678</subfield>
       <subfield code="5">DLC</subfield>

--- a/xsl/ConvSpec-240andX30-UnifTitle.xsl
+++ b/xsl/ConvSpec-240andX30-UnifTitle.xsl
@@ -251,7 +251,7 @@
             </bf:language>
           </xsl:if>
         </xsl:if>
-        <xsl:if test="not(../marc:datafield[@tag='382'])">
+        <xsl:if test="not($tag='130' or $tag='240') or not(../marc:datafield[@tag='382'])">
           <xsl:for-each select="marc:subfield[@code='m']">
             <bf:musicMedium>
               <bf:MusicMedium>
@@ -269,7 +269,7 @@
             </bf:musicMedium>
           </xsl:for-each>
         </xsl:if>
-        <xsl:if test="not(../marc:datafield[@tag='384'])">
+        <xsl:if test="not($tag='130' or $tag='240') or not(../marc:datafield[@tag='384'])">
           <xsl:for-each select="marc:subfield[@code='r']">
             <bf:musicKey>
               <xsl:if test="$vXmlLang != ''">


### PR DESCRIPTION
Do not consider presence of 382 or 384 when creating musicMedium or musicKey for uniform titles that are not main entries.