### PR TITLE
Clean up handling of ind2=7 and $2 for 600-630

### DIFF
--- a/test/data/ConvSpec-240andX30-UnifTitle/marc.xml
+++ b/test/data/ConvSpec-240andX30-UnifTitle/marc.xml
@@ -19,7 +19,7 @@
       <subfield code="a">Latin American lives :</subfield>
       <subfield code="b">selected biographies from the five-volume Encyclopedia of Latin American history and culture.</subfield>
     </datafield>
-    <datafield tag="630" ind1="0" ind2="0">
+    <datafield tag="630" ind1="0" ind2="7">
       <subfield code="a">Ukrainian weekly</subfield>
       <subfield code="e">depicted.</subfield>
       <subfield code="v">Indexes</subfield>

--- a/test/marc2bibframe2.xspec
+++ b/test/marc2bibframe2.xspec
@@ -582,14 +582,14 @@
                 <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName" />
                 <madsrdf:authoritativeLabel>White House (Washington, D.C.)</madsrdf:authoritativeLabel>
                 <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects" />
+                <bflc:name10MatchKey>White House (Washington, D.C.)</bflc:name10MatchKey>
+                <bflc:name10MarcKey>61020$aWhite House (Washington, D.C.)</bflc:name10MarcKey>
+                <rdfs:label>White House (Washington, D.C.)</rdfs:label>
                 <bf:source>
                   <bf:Source rdf:about="http://id.loc.gov/authorities/subjects">
                     <bf:code>lcsh</bf:code>
                   </bf:Source>
                 </bf:source>
-                <bflc:name10MatchKey>White House (Washington, D.C.)</bflc:name10MatchKey>
-                <bflc:name10MarcKey>61020$aWhite House (Washington, D.C.)</bflc:name10MarcKey>
-                <rdfs:label>White House (Washington, D.C.)</rdfs:label>
               </bf:Agent>
             </bf:subject>
             <bf:subject>
@@ -598,14 +598,14 @@
                 <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName" />
                 <madsrdf:authoritativeLabel>United States. Executive Office of the President.</madsrdf:authoritativeLabel>
                 <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects" />
+                <bflc:name10MatchKey>United States. Executive Office of the President.</bflc:name10MatchKey>
+                <bflc:name10MarcKey>61010$aUnited States.$bExecutive Office of the President.</bflc:name10MarcKey>
+                <rdfs:label>United States. Executive Office of the President.</rdfs:label>
                 <bf:source>
                   <bf:Source rdf:about="http://id.loc.gov/authorities/subjects">
                     <bf:code>lcsh</bf:code>
                   </bf:Source>
                 </bf:source>
-                <bflc:name10MatchKey>United States. Executive Office of the President.</bflc:name10MatchKey>
-                <bflc:name10MarcKey>61010$aUnited States.$bExecutive Office of the President.</bflc:name10MarcKey>
-                <rdfs:label>United States. Executive Office of the President.</rdfs:label>
               </bf:Agent>
             </bf:subject>
             <bf:subject>
@@ -614,14 +614,14 @@
                 <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName" />
                 <madsrdf:authoritativeLabel>United States. Office of the Vice President.</madsrdf:authoritativeLabel>
                 <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects" />
+                <bflc:name10MatchKey>United States. Office of the Vice President.</bflc:name10MatchKey>
+                <bflc:name10MarcKey>61010$aUnited States.$bOffice of the Vice President.</bflc:name10MarcKey>
+                <rdfs:label>United States. Office of the Vice President.</rdfs:label>
                 <bf:source>
                   <bf:Source rdf:about="http://id.loc.gov/authorities/subjects">
                     <bf:code>lcsh</bf:code>
                   </bf:Source>
                 </bf:source>
-                <bflc:name10MatchKey>United States. Office of the Vice President.</bflc:name10MatchKey>
-                <bflc:name10MarcKey>61010$aUnited States.$bOffice of the Vice President.</bflc:name10MarcKey>
-                <rdfs:label>United States. Office of the Vice President.</rdfs:label>
               </bf:Agent>
             </bf:subject>
             <bf:subject>
@@ -630,14 +630,14 @@
                 <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName" />
                 <madsrdf:authoritativeLabel>United States. Office of the First Lady.</madsrdf:authoritativeLabel>
                 <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects" />
+                <bflc:name10MatchKey>United States. Office of the First Lady.</bflc:name10MatchKey>
+                <bflc:name10MarcKey>61010$aUnited States.$bOffice of the First Lady.</bflc:name10MarcKey>
+                <rdfs:label>United States. Office of the First Lady.</rdfs:label>
                 <bf:source>
                   <bf:Source rdf:about="http://id.loc.gov/authorities/subjects">
                     <bf:code>lcsh</bf:code>
                   </bf:Source>
                 </bf:source>
-                <bflc:name10MatchKey>United States. Office of the First Lady.</bflc:name10MatchKey>
-                <bflc:name10MarcKey>61010$aUnited States.$bOffice of the First Lady.</bflc:name10MarcKey>
-                <rdfs:label>United States. Office of the First Lady.</rdfs:label>
               </bf:Agent>
             </bf:subject>
             <bf:contribution>

--- a/xsl/ConvSpec-1XX,7XX,8XX-names.xsl
+++ b/xsl/ConvSpec-1XX,7XX,8XX-names.xsl
@@ -165,6 +165,7 @@
     <xsl:param name="agentiri"/>
     <xsl:param name="recordid"/>
     <xsl:param name="serialization"/>
+    <xsl:param name="pSource"/>
     <xsl:variable name="tag">
       <xsl:choose>
         <xsl:when test="@tag=880">
@@ -205,6 +206,7 @@
               <xsl:apply-templates mode="agent" select=".">
                 <xsl:with-param name="agentiri" select="$agentiri"/>
                 <xsl:with-param name="serialization" select="$serialization"/>
+                <xsl:with-param name="pSource" select="$pSource"/>
               </xsl:apply-templates>
             </bf:agent>
             <xsl:choose>
@@ -242,6 +244,7 @@
     <xsl:if test="marc:subfield[@code='t']">
       <xsl:apply-templates mode="workUnifTitle" select=".">
         <xsl:with-param name="serialization" select="$serialization"/>
+        <xsl:with-param name="pSource" select="$pSource"/>
       </xsl:apply-templates>
     </xsl:if>
   </xsl:template>
@@ -575,9 +578,6 @@
                 </madsrdf:isMemberOfMADSScheme>
               </xsl:for-each>
             </xsl:if>
-            <xsl:if test="$pSource != ''">
-              <xsl:copy-of select="$pSource"/>
-            </xsl:if>
             <xsl:if test="not(marc:subfield[@code='t'])">
               <xsl:choose>
                 <xsl:when test="substring($tag,2,2)='11'">
@@ -702,10 +702,17 @@
                   </xsl:apply-templates>
                 </xsl:if>
               </xsl:for-each>
-              <xsl:apply-templates mode="subfield2" select="marc:subfield[@code='2']">
-                <xsl:with-param name="serialization" select="$serialization"/>
-                <xsl:with-param name="pVocabStem" select="$nametitleschemes"/>
-              </xsl:apply-templates>
+              <xsl:choose>
+                <xsl:when test="$pSource != ''">
+                  <xsl:copy-of select="$pSource"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:apply-templates mode="subfield2" select="marc:subfield[@code='2']">
+                    <xsl:with-param name="serialization" select="$serialization"/>
+                    <xsl:with-param name="pVocabStem" select="$nametitleschemes"/>
+                  </xsl:apply-templates>
+                </xsl:otherwise>
+              </xsl:choose>
               <xsl:apply-templates mode="subfield3" select="marc:subfield[@code='3']">
                 <xsl:with-param name="serialization" select="$serialization"/>
               </xsl:apply-templates>

--- a/xsl/ConvSpec-240andX30-UnifTitle.xsl
+++ b/xsl/ConvSpec-240andX30-UnifTitle.xsl
@@ -136,6 +136,7 @@
     <xsl:param name="serialization" select="'rdfxml'"/>
     <xsl:param name="pUnifTitleMode"/>
     <xsl:param name="pWorkUri"/>
+    <xsl:param name="pSource"/>
     <xsl:variable name="tag">
       <xsl:choose>
         <xsl:when test="@tag=880">
@@ -343,9 +344,16 @@
               </xsl:for-each>
             </xsl:otherwise>
           </xsl:choose>
-          <xsl:apply-templates mode="subfield2" select="marc:subfield[@code='2']">
-            <xsl:with-param name="serialization" select="$serialization"/>
-          </xsl:apply-templates>
+          <xsl:choose>
+            <xsl:when test="$pSource != ''">
+              <xsl:copy-of select="$pSource"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:apply-templates mode="subfield2" select="marc:subfield[@code='2']">
+                <xsl:with-param name="serialization" select="$serialization"/>
+              </xsl:apply-templates>
+            </xsl:otherwise>
+          </xsl:choose>
           <xsl:apply-templates mode="subfield3" select="marc:subfield[@code='3']">
             <xsl:with-param name="serialization" select="$serialization"/>
           </xsl:apply-templates>

--- a/xsl/ConvSpec-600-662.xsl
+++ b/xsl/ConvSpec-600-662.xsl
@@ -530,9 +530,6 @@
               <xsl:attribute name="rdf:resource"><xsl:value-of select="."/></xsl:attribute>
             </madsrdf:isMemberOfMADSScheme>
           </xsl:for-each>                  
-          <xsl:if test="$pSource != ''">
-            <xsl:copy-of select="$pSource"/>
-          </xsl:if>
           <xsl:apply-templates select="marc:subfield[@code='e']" mode="contributionRole">
             <xsl:with-param name="serialization" select="$serialization"/>
             <xsl:with-param name="pMode">relationship</xsl:with-param>
@@ -559,6 +556,7 @@
           </xsl:for-each>
           <xsl:apply-templates select="." mode="workUnifTitle">
             <xsl:with-param name="serialization" select="$serialization"/>
+            <xsl:with-param name="pSource" select="$pSource"/>
           </xsl:apply-templates>
         </bf:Work>
       </xsl:when>


### PR DESCRIPTION
Do not process $2 for names and titles if source is set by ind2. For fields with ind2=7 (or 4), only process $2 once and give the code the correct scheme (subjects rather than names).