### PR TITLE
Remove incorrect namespace declaration for "http://www.w3.org/2005/xp…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+--- 1.7.0-SNAPSHOT
+
+Remove namespace declaration for xpath-functions (fix bug with current-dateTime())
+
 --- 1.6.1 2020/12/14
 
 Fix bad agent URIs minted in 240/X30 processing (https://github.com/lcnetdev/marc2bibframe2/issues/192)

--- a/xsl/marc2bibframe2.xsl
+++ b/xsl/marc2bibframe2.xsl
@@ -8,8 +8,7 @@
                 xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:date="http://exslt.org/dates-and-times"
-                xmlns:fn="http://www.w3.org/2005/xpath-function"
-                extension-element-prefixes="date fn"
+                extension-element-prefixes="date"
                 exclude-result-prefixes="xsl marc">
 
   <xsl:output encoding="UTF-8" method="xml" indent="yes"/>
@@ -55,8 +54,8 @@
       <xsl:when test="function-available('date:date-time')">
         <xsl:value-of select="date:date-time()"/>
       </xsl:when>
-      <xsl:when test="function-available('fn:current-dateTime')">
-        <xsl:value-of select="fn:current-dateTime()"/>
+      <xsl:when test="function-available('current-dateTime')">
+        <xsl:value-of select="current-dateTime()"/>
       </xsl:when>
     </xsl:choose>
   </xsl:param>


### PR DESCRIPTION
…ath-functions"

That namespace is implicit and reserved, so should not be declared. This also fixes a long-standing bug that would prevent the Saxon XSLT process (which supports the current-dateTime() function from that namespace) from generating a proper record datestamp.