### PR TITLE
Normalize URIs created as source properties from 336/337/338 $b.

### DIFF
--- a/xsl/ConvSpec-3XX.xsl
+++ b/xsl/ConvSpec-3XX.xsl
@@ -662,9 +662,14 @@
                 </xsl:apply-templates>
               </xsl:if>
               <xsl:for-each select="../marc:subfield[@code='2']">
+                <xsl:variable name="vCode">
+                  <xsl:call-template name="tNormalizeCode">
+                    <xsl:with-param name="pCode" select="."/>
+                  </xsl:call-template>
+                </xsl:variable>
                 <bf:source>
                   <bf:Source>
-                    <xsl:attribute name="rdf:about"><xsl:value-of select="concat($genreFormSchemes,.)"/></xsl:attribute>
+                    <xsl:attribute name="rdf:about"><xsl:value-of select="concat($genreFormSchemes,$vCode)"/></xsl:attribute>
                   </bf:Source>
                 </bf:source>
               </xsl:for-each>


### PR DESCRIPTION
Was already happening for $a, not sure why we missed $b. Fixes #219.